### PR TITLE
Fix offset for power mode, add scale factor for power mode

### DIFF
--- a/common/rawaccel-userspace.hpp
+++ b/common/rawaccel-userspace.hpp
@@ -84,7 +84,8 @@ variables parse(int argc, char** argv) {
     );
     auto pow_mode = "power accel mode:" % (
         clipp::command("power").set(accel_args.accel_mode, mode::power),
-        accel_var
+        accel_var,
+        (clipp::option("scale") & clipp::number("num", accel_args.lim_exp)) % "scale factor"
     );
 
     auto accel_mode_exclusive = (lin_mode | classic_mode | nat_mode | log_mode | sig_mode | pow_mode);

--- a/common/rawaccel.hpp
+++ b/common/rawaccel.hpp
@@ -74,7 +74,8 @@ struct accel_function {
     double b = 0; 
 
     // the limit for natural and sigmoid modes,
-    // or the exponent for classic mode
+    // the exponent for classic mode,
+    // or the scale factor for power mode
     double k = 1; 
     
     vec2d weight = { 1, 1 };
@@ -98,7 +99,7 @@ struct accel_function {
             break;
         case mode::sigmoid: accel_val = k / (exp(-b * (speed - m)) + 1); 
             break;
-        case mode::power: accel_val = pow(speed, b) - 1;
+        case mode::power: accel_val = b < 1 ? 0 : pow(speed, b*k) - 1;
             break;
         default:
             break;
@@ -131,6 +132,7 @@ struct accel_function {
         if (args.time_min <= 0) error("min time must be positive");
         if (args.lim_exp <= 1) {
             if (args.accel_mode == mode::classic) error("exponent must be greater than 1");
+            else if (args.accel_mode == mode::power) error("scale factor must be greater than 1");
             else error("limit must be greater than 1");
         }
 

--- a/common/rawaccel.hpp
+++ b/common/rawaccel.hpp
@@ -141,6 +141,7 @@ struct accel_function {
         b = args.accel;
         k = args.lim_exp - 1;
         if (args.accel_mode == mode::natural) b /= k;
+        if (args.accel_mode == mode::power) k++;
         
         speed_offset = args.offset;
         weight = args.weight;

--- a/common/rawaccel.hpp
+++ b/common/rawaccel.hpp
@@ -99,7 +99,7 @@ struct accel_function {
             break;
         case mode::sigmoid: accel_val = k / (exp(-b * (speed - m)) + 1); 
             break;
-        case mode::power: accel_val = b < 1 ? 0 : pow(speed, b*k) - 1;
+        case mode::power: accel_val = (speed_offset > 0 && speed < 1) ? 0 : pow(speed, b*k) - 1;
             break;
         default:
             break;


### PR DESCRIPTION
The previous implementation of power mode would cause negative acceleration for velocities just greater than the offset. This change fixes that by only applying acceleration when the result will be greater than 1.

This change also adds a "scale factor" variable for the power mode so that players coming from games with FPS-dependent acceleration can scale the velocity by a certain factor to match their game and mouse setup.