### PR TITLE
Power style: additional fixes

### DIFF
--- a/common/rawaccel-userspace.hpp
+++ b/common/rawaccel-userspace.hpp
@@ -83,9 +83,9 @@ variables parse(int argc, char** argv) {
         (clipp::required("midpoint") & clipp::number("speed", accel_args.midpoint)) % "midpoint"
     );
     auto pow_mode = "power accel mode:" % (
-        clipp::command("power").set(accel_args.accel_mode, mode::power),
-        accel_var,
-        (clipp::option("scale") & clipp::number("num", accel_args.lim_exp)) % "scale factor"
+        clipp::command("power").set(accel_args.accel_mode, mode::power) >> [&] { accel_args.accel = 1; },
+        (clipp::required("exponent") & clipp::number("num", accel_args.lim_exp)) % "exponent",
+        (clipp::option("scale") & clipp::number("num", accel_args.accel)) % "scale factor"
     );
 
     auto accel_mode_exclusive = (lin_mode | classic_mode | nat_mode | log_mode | sig_mode | pow_mode);

--- a/common/rawaccel.hpp
+++ b/common/rawaccel.hpp
@@ -99,7 +99,7 @@ struct accel_function {
             break;
         case mode::sigmoid: accel_val = k / (exp(-b * (speed - m)) + 1); 
             break;
-        case mode::power: accel_val = (speed_offset > 0 && speed < 1) ? 0 : pow(speed, b*k) - 1;
+        case mode::power: accel_val = (speed_offset > 0 && speed < 1) ? 0 : pow(speed*k, b) - 1;
             break;
         default:
             break;
@@ -132,7 +132,7 @@ struct accel_function {
         if (args.time_min <= 0) error("min time must be positive");
         if (args.lim_exp <= 1) {
             if (args.accel_mode == mode::classic) error("exponent must be greater than 1");
-            else if (args.accel_mode == mode::power) error("scale factor must be greater than 1");
+            else if (args.accel_mode == mode::power) { if (args.lim_exp <= 0) error("scale factor must be greater than 0"); }
             else error("limit must be greater than 1");
         }
 

--- a/common/rawaccel.hpp
+++ b/common/rawaccel.hpp
@@ -73,9 +73,8 @@ struct accel_function {
     // accel ramp rate
     double b = 0; 
 
-    // the limit for natural and sigmoid modes,
-    // the exponent for classic mode,
-    // or the scale factor for power mode
+    // the limit for natural and sigmoid modes
+    // or the exponent for classic and power modes
     double k = 1; 
     
     vec2d weight = { 1, 1 };
@@ -99,7 +98,7 @@ struct accel_function {
             break;
         case mode::sigmoid: accel_val = k / (exp(-b * (speed - m)) + 1); 
             break;
-        case mode::power: accel_val = (speed_offset > 0 && speed < 1) ? 0 : pow(speed*k, b) - 1;
+        case mode::power: accel_val = (speed_offset > 0 && speed < 1) ? 0 : pow(speed*b, k) - 1;
             break;
         default:
             break;
@@ -132,7 +131,7 @@ struct accel_function {
         if (args.time_min <= 0) error("min time must be positive");
         if (args.lim_exp <= 1) {
             if (args.accel_mode == mode::classic) error("exponent must be greater than 1");
-            else if (args.accel_mode == mode::power) { if (args.lim_exp <= 0) error("scale factor must be greater than 0"); }
+            if (args.accel_mode == mode::power) { if (args.lim_exp <=0 ) error("exponent must be greater than 0"); }
             else error("limit must be greater than 1");
         }
 


### PR DESCRIPTION
The scale factor should be applied to speed to allow speed to be scaled for users coming from environments with drawn-frames-per-second-dependent acceleration.

The scale factor can be any value greater than 0, so the argument check in accel_function has been updated to reflect this.