### PR TITLE
GUI Fix: Anisotropy now loads correctly

### DIFF
--- a/grapher/Models/Options/ApplyOptions.cs
+++ b/grapher/Models/Options/ApplyOptions.cs
@@ -114,9 +114,10 @@ namespace grapher.Models.Options
             Sensitivity.SetActiveValues(xSens, ySens);
             Rotation.SetActiveValue(rotation);
             OptionSetX.SetActiveValues(xMode, xArgs);
-            OptionSetY.SetActiveValues(yMode, yArgs);
             WholeVectorMenuItem.Checked = isWhole;
             ByComponentVectorMenuItem.Checked = !isWhole;
+            ByComponentVectorXYLock.Checked = xArgs.Equals(yArgs);
+            OptionSetY.SetActiveValues(yMode, yArgs);
         }
 
         public void SetActiveValues(DriverSettings settings)


### PR DESCRIPTION
Anisotropy - separate x and y curves in By Component mode - was not loading right before this fix; regardless of the settings, the x and y settings would show as equal in the GUI. This fix changes that by checking equality of the structs to know whether to display the y separately.