### PR TITLE
Add smoothing

### DIFF
--- a/common/accel-motivity.hpp
+++ b/common/accel-motivity.hpp
@@ -24,7 +24,6 @@ namespace rawaccel {
 			double denom = exp(accel * (midpoint - log(x))) + 1;
 			return exp(motivity / denom + constant);
 		}
-
 	};
 
 	template <>

--- a/common/rawaccel-base.hpp
+++ b/common/rawaccel-base.hpp
@@ -69,9 +69,8 @@ namespace rawaccel {
         bool whole = true;
         double lp_norm = 2;
         bool should_smooth = false;
-        double smooth_window = 100;
-        bool use_cutoff = false;
-        double cutoff_window = 10;
+        double smooth_window = 70;
+        bool use_linear = false;
     };
 
     struct profile {

--- a/common/rawaccel-base.hpp
+++ b/common/rawaccel-base.hpp
@@ -19,8 +19,6 @@ namespace rawaccel {
     inline constexpr size_t LUT_RAW_DATA_CAPACITY = 514;
     inline constexpr size_t LUT_POINTS_CAPACITY = LUT_RAW_DATA_CAPACITY / 2;
 
-    inline constexpr size_t SMOOTH_RAW_DATA_CAPACITY = 8192;
-
     inline constexpr double MAX_NORM = 16;
 
     inline constexpr bool LEGACY = 0;
@@ -82,7 +80,7 @@ namespace rawaccel {
 
         accel_args accel_x;
         accel_args accel_y;
-        speed_args input_speed_args;
+        speed_args speed_processor_args;
 
         double sensitivity = 1;
         double yx_sens_ratio = 1;

--- a/common/rawaccel-base.hpp
+++ b/common/rawaccel-base.hpp
@@ -19,6 +19,8 @@ namespace rawaccel {
     inline constexpr size_t LUT_RAW_DATA_CAPACITY = 514;
     inline constexpr size_t LUT_POINTS_CAPACITY = LUT_RAW_DATA_CAPACITY / 2;
 
+    inline constexpr size_t SMOOTH_RAW_DATA_CAPACITY = 8192;
+
     inline constexpr double MAX_NORM = 16;
 
     inline constexpr bool LEGACY = 0;
@@ -62,6 +64,15 @@ namespace rawaccel {
         mutable float data[LUT_RAW_DATA_CAPACITY] = {};
     };
 
+    struct input_speed_args
+    {
+        bool whole = true;
+        double lp_norm = 2;
+        bool should_smooth = false;
+        double smooth_window = 100;
+        bool use_cutoff = false;
+        double cutoff_window = 10;
+    };
 
     struct profile {
         wchar_t name[MAX_NAME_LEN] = L"default";
@@ -73,6 +84,7 @@ namespace rawaccel {
 
         accel_args accel_x;
         accel_args accel_y;
+        input_speed_args input_speed_args;
 
         double sensitivity = 1;
         double yx_sens_ratio = 1;

--- a/common/rawaccel-base.hpp
+++ b/common/rawaccel-base.hpp
@@ -64,14 +64,15 @@ namespace rawaccel {
         mutable float data[LUT_RAW_DATA_CAPACITY] = {};
     };
 
-    struct input_speed_args
+    struct speed_args
     {
         bool whole = true;
         double lp_norm = 2;
-        bool should_smooth = false;
-        double smooth_halflife = 25;
-        bool use_linear = false;
+        double input_speed_smooth_halflife = 10;
+        double scale_smooth_halflife = 0;
+        double output_speed_smooth_halflife = 0;
     };
+
 
     struct profile {
         wchar_t name[MAX_NAME_LEN] = L"default";
@@ -81,7 +82,7 @@ namespace rawaccel {
 
         accel_args accel_x;
         accel_args accel_y;
-        input_speed_args input_speed_args;
+        speed_args input_speed_args;
 
         double sensitivity = 1;
         double yx_sens_ratio = 1;

--- a/common/rawaccel-base.hpp
+++ b/common/rawaccel-base.hpp
@@ -69,7 +69,7 @@ namespace rawaccel {
         bool whole = true;
         double lp_norm = 2;
         bool should_smooth = false;
-        double smooth_window = 70;
+        double smooth_halflife = 25;
         bool use_linear = false;
     };
 

--- a/common/rawaccel-base.hpp
+++ b/common/rawaccel-base.hpp
@@ -66,7 +66,7 @@ namespace rawaccel {
     {
         bool whole = true;
         double lp_norm = 2;
-        double input_speed_smooth_halflife = 10;
+        double input_speed_smooth_halflife = 0;
         double scale_smooth_halflife = 0;
         double output_speed_smooth_halflife = 0;
     };

--- a/common/rawaccel-base.hpp
+++ b/common/rawaccel-base.hpp
@@ -77,8 +77,6 @@ namespace rawaccel {
     struct profile {
         wchar_t name[MAX_NAME_LEN] = L"default";
 
-        bool whole = true;
-        double lp_norm = 2;
         vec2d domain_weights = { 1, 1 };
         vec2d range_weights = { 1, 1 };
 

--- a/common/rawaccel-validate.hpp
+++ b/common/rawaccel-validate.hpp
@@ -132,7 +132,7 @@ namespace rawaccel {
 
 		check_accel(args.accel_x);
 
-		if (!args.input_speed_args.whole) {
+		if (!args.speed_processor_args.whole) {
 			ret.last_x = ret.count;
 			check_accel(args.accel_y);
 			ret.last_y = ret.count;
@@ -170,7 +170,7 @@ namespace rawaccel {
 			error("sens ratio must be positive");
 		}
 
-		if (args.input_speed_args.lp_norm <= 0) {
+		if (args.speed_processor_args.lp_norm <= 0) {
 			error("Lp norm must be positive (default=2)");
 		}
 

--- a/common/rawaccel-validate.hpp
+++ b/common/rawaccel-validate.hpp
@@ -132,7 +132,7 @@ namespace rawaccel {
 
 		check_accel(args.accel_x);
 
-		if (!args.whole) {
+		if (!args.input_speed_args.whole) {
 			ret.last_x = ret.count;
 			check_accel(args.accel_y);
 			ret.last_y = ret.count;
@@ -170,7 +170,7 @@ namespace rawaccel {
 			error("sens ratio must be positive");
 		}
 
-		if (args.lp_norm <= 0) {
+		if (args.input_speed_args.lp_norm <= 0) {
 			error("Lp norm must be positive (default=2)");
 		}
 

--- a/common/rawaccel.hpp
+++ b/common/rawaccel.hpp
@@ -208,46 +208,46 @@ namespace rawaccel {
                 speed_flags.dist_mode = distance_mode::euclidean;
             }
 
-			speed_flags.should_smooth_input = in_args.input_speed_smooth_halflife > 0;
-			speed_flags.should_smooth_scale = in_args.scale_smooth_halflife > 0;
-			speed_flags.should_smooth_output = in_args.output_speed_smooth_halflife > 0;
+            speed_flags.should_smooth_input = in_args.input_speed_smooth_halflife > 0;
+            speed_flags.should_smooth_scale = in_args.scale_smooth_halflife > 0;
+            speed_flags.should_smooth_output = in_args.output_speed_smooth_halflife > 0;
 
             if (speed_flags.should_smooth_input)
             {
-				smoother_x.input_speed_smoother.init(in_args.input_speed_smooth_halflife, input_trend_halflife);
-				smoother_y.input_speed_smoother.init(in_args.input_speed_smooth_halflife, input_trend_halflife);
+                smoother_x.input_speed_smoother.init(in_args.input_speed_smooth_halflife, input_trend_halflife);
+                smoother_y.input_speed_smoother.init(in_args.input_speed_smooth_halflife, input_trend_halflife);
             }
 
             if (speed_flags.should_smooth_scale)
             {
-				smoother_x.scale_smoother.init(in_args.scale_smooth_halflife);
-				smoother_y.scale_smoother.init(in_args.scale_smooth_halflife);
+                smoother_x.scale_smoother.init(in_args.scale_smooth_halflife);
+                smoother_y.scale_smoother.init(in_args.scale_smooth_halflife);
             }
 
             if (speed_flags.should_smooth_output)
             {
-				smoother_x.output_speed_smoother.init(in_args.output_speed_smooth_halflife, output_trend_halflife);
-				smoother_y.output_speed_smoother.init(in_args.output_speed_smooth_halflife, output_trend_halflife);
+                smoother_x.output_speed_smoother.init(in_args.output_speed_smooth_halflife, output_trend_halflife);
+                smoother_y.output_speed_smoother.init(in_args.output_speed_smooth_halflife, output_trend_halflife);
             }
         }
 
         double calc_speed_whole(vec2d in, milliseconds time)
         {
-			double speed;
+            double speed;
 
-			if (speed_flags.dist_mode == distance_mode::max) {
-				speed = maxsd(in.x, in.y);
-			}
-			else if (speed_flags.dist_mode == distance_mode::Lp) {
-				speed = lp_distance(in, args.lp_norm);
-			}
-			else {
-				speed = magnitude(in);
-			}
+            if (speed_flags.dist_mode == distance_mode::max) {
+                speed = maxsd(in.x, in.y);
+            }
+            else if (speed_flags.dist_mode == distance_mode::Lp) {
+                speed = lp_distance(in, args.lp_norm);
+            }
+            else {
+                speed = magnitude(in);
+            }
 
             if (speed_flags.should_smooth_input)
             {
-				speed = smoother_x.input_speed_smoother.smooth(speed, time);
+                speed = smoother_x.input_speed_smoother.smooth(speed, time);
             }
 
             return speed;
@@ -255,13 +255,13 @@ namespace rawaccel {
 
         void calc_speed_separate(vec2d& in, milliseconds time)
         {
-			double speed_x = in.x;
-			double speed_y = in.y;
+            double speed_x = in.x;
+            double speed_y = in.y;
 
             if (speed_flags.should_smooth_input)
             {
-				speed_x = smoother_x.input_speed_smoother.smooth(speed_x, time);
-				speed_y = smoother_y.input_speed_smoother.smooth(speed_y, time);
+                speed_x = smoother_x.input_speed_smoother.smooth(speed_x, time);
+                speed_y = smoother_y.input_speed_smoother.smooth(speed_y, time);
             }
 
             in.x = speed_x;

--- a/common/rawaccel.hpp
+++ b/common/rawaccel.hpp
@@ -45,7 +45,7 @@ namespace rawaccel {
             clamp_speed = args.speed_max > 0 && args.speed_min <= args.speed_max;
             apply_rotate = args.degrees_rotation != 0;
             apply_snap = args.degrees_snap != 0;
-            apply_directional_weight = args.input_speed_args.whole && 
+            apply_directional_weight = args.speed_processor_args.whole && 
                 args.range_weights.x != args.range_weights.y;
             compute_ref_angle = apply_snap || apply_directional_weight;
             apply_dir_mul_x = args.lr_sens_ratio != 1;
@@ -65,6 +65,9 @@ namespace rawaccel {
 
         void init(const double halfLife)
         {
+            windowTotal = 0;
+            cutoffTotal = 0;
+
             windowCoefficient = halfLife > 0 ? pow(0.5, 1 / halfLife) : 0;
             cutoffCoefficient = 1.0 - sqrt(1.0 - windowCoefficient);
         }
@@ -299,7 +302,6 @@ namespace rawaccel {
         unsigned device_data_size = 0;
     };
 
-
     static_assert(alignof(io_base) == alignof(modifier_settings) && alignof(modifier_settings) == alignof(device_settings));
 
     class modifier {
@@ -394,16 +396,16 @@ namespace rawaccel {
                 in.x *= scale;
                 in.y *= scale;
 
-				if (speed_processor.speed_flags.should_smooth_output)
-				{
-					double mag = magnitude(in);
-					if (mag > 0)
-					{
-						double smoothedMag = speed_processor.smoother_x.output_speed_smoother.smooth(mag, time);
-						in.x *= (smoothedMag / mag);
-						in.y *= (smoothedMag / mag);
-					}
-				}
+                if (speed_processor.speed_flags.should_smooth_output)
+                {
+                    double mag = magnitude(in);
+                    if (mag > 0)
+                    {
+                        double smoothedMag = speed_processor.smoother_x.output_speed_smoother.smooth(mag, time);
+                        in.x *= (smoothedMag / mag);
+                        in.y *= (smoothedMag / mag);
+                    }
+                }
             }
 
             double dpi_adjusted_sens = args.sensitivity * dpi_factor;

--- a/common/rawaccel.hpp
+++ b/common/rawaccel.hpp
@@ -370,8 +370,8 @@ namespace rawaccel {
 
                 if (speed_processor.speed_flags.should_smooth_output)
                 {
-                    in.x = speed_processor.smoother_x.output_speed_smoother.smooth(scale_x, time);
-                    in.y = speed_processor.smoother_y.output_speed_smoother.smooth(scale_y, time);
+                    in.x = _copysign(speed_processor.smoother_x.output_speed_smoother.smooth(fabs(in.x), time), in.x);
+                    in.y = _copysign(speed_processor.smoother_y.output_speed_smoother.smooth(fabs(in.y), time), in.y);
                 }
             }
             else {

--- a/common/rawaccel.hpp
+++ b/common/rawaccel.hpp
@@ -96,7 +96,7 @@ namespace rawaccel {
 
         // This constant found via experimentation.
         // Allowing user to specify may confuse parameterization without much gain.
-        const double trendDampening = 0.75;
+        static constexpr double trendDampening = 0.75;
 
         double windowCoefficient = 0;
         double cutoffCoefficient = 0;
@@ -186,8 +186,8 @@ namespace rawaccel {
         smoother smoother_x = {};
         smoother smoother_y = {};
 
-        const double input_trend_halflife = 1.25;
-        const double output_trend_halflife = 0.7;
+        static constexpr double input_trend_halflife = 1.25;
+        static constexpr double output_trend_halflife = 0.7;
 
         speed_processor() = default;
 

--- a/common/rawaccel.hpp
+++ b/common/rawaccel.hpp
@@ -60,7 +60,7 @@ namespace rawaccel {
         input_speed_args speed_args = {};
         distance_mode dist_mode = {};
 
-        const double trendAge = 2.5;
+        const double trendHalflife = 1.25;
 
         double windowCoefficient = 0;
         double cutoffCoefficient = 0;
@@ -84,9 +84,8 @@ namespace rawaccel {
                 dist_mode = distance_mode::euclidean;
             }
 
-            double averageAge = fabs(speed_args.smooth_window / 2.0);
-            windowCoefficient = averageAge > 0 ? exp(-1.0 / averageAge) : 0;
-            windowTrendCoefficient = trendAge > 0 ? exp(-1.0 / trendAge) : 0;
+            windowCoefficient = args.smooth_halflife > 0 ? pow(0.5, 1 / args.smooth_halflife) : 0;
+            windowTrendCoefficient = trendHalflife > 0 ? pow(0.5, 1 / trendHalflife) : 0;
             cutoffCoefficient = 1.0 - sqrt(1.0 - windowCoefficient);
             cutoffTrendCoefficient = 1.0 - sqrt(1.0 - windowTrendCoefficient);
         }
@@ -106,7 +105,7 @@ namespace rawaccel {
 			}
 
             if (speed_args.should_smooth &&
-                speed_args.smooth_window > 0)
+                speed_args.smooth_halflife > 0)
             {
                 if (speed_args.use_linear)
                 {

--- a/common/rawaccel.hpp
+++ b/common/rawaccel.hpp
@@ -45,7 +45,7 @@ namespace rawaccel {
             clamp_speed = args.speed_max > 0 && args.speed_min <= args.speed_max;
             apply_rotate = args.degrees_rotation != 0;
             apply_snap = args.degrees_snap != 0;
-            apply_directional_weight = args.whole && 
+            apply_directional_weight = args.input_speed_args.whole && 
                 args.range_weights.x != args.range_weights.y;
             compute_ref_angle = apply_snap || apply_directional_weight;
             apply_dir_mul_x = args.lr_sens_ratio != 1;

--- a/converter/converter.vcxproj
+++ b/converter/converter.vcxproj
@@ -22,14 +22,14 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
     <CLRSupport>true</CLRSupport>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <WholeProgramOptimization>false</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
     <CLRSupport>true</CLRSupport>

--- a/driver/driver.cpp
+++ b/driver/driver.cpp
@@ -380,7 +380,7 @@ DeviceSetup(WDFOBJECT hDevice)
             if (wcsncmp(prof_name, profile.name, ra::MAX_NAME_LEN) == 0) {
                 devExt->mod_settings = global.modifier_data[i];
                 devExt->mod = { devExt->mod_settings };
-                devExt->speed_processor.init(devExt->mod_settings.prof.input_speed_args);
+                devExt->speed_processor.init(devExt->mod_settings.prof.speed_processor_args);
                 return;
             }
         }
@@ -395,7 +395,7 @@ DeviceSetup(WDFOBJECT hDevice)
     set_ext_from_cfg(global.base_data.default_dev_cfg);
     devExt->mod_settings = *global.modifier_data;
     devExt->mod = { devExt->mod_settings };
-	devExt->speed_processor.init(devExt->mod_settings.prof.input_speed_args);
+    devExt->speed_processor.init(devExt->mod_settings.prof.speed_processor_args);
     
     for (auto i = 0u; i < global.base_data.device_data_size; i++) {
         auto& dev_settings = global.device_data[i];

--- a/driver/driver.cpp
+++ b/driver/driver.cpp
@@ -395,6 +395,7 @@ DeviceSetup(WDFOBJECT hDevice)
     set_ext_from_cfg(global.base_data.default_dev_cfg);
     devExt->mod_settings = *global.modifier_data;
     devExt->mod = { devExt->mod_settings };
+	devExt->speed_processor.init(devExt->mod_settings.prof.input_speed_args);
     
     for (auto i = 0u; i < global.base_data.device_data_size; i++) {
         auto& dev_settings = global.device_data[i];

--- a/driver/driver.cpp
+++ b/driver/driver.cpp
@@ -380,6 +380,7 @@ DeviceSetup(WDFOBJECT hDevice)
             if (wcsncmp(prof_name, profile.name, ra::MAX_NAME_LEN) == 0) {
                 devExt->mod_settings = global.modifier_data[i];
                 devExt->mod = { devExt->mod_settings };
+                devExt->speed_processor.init(devExt->mod_settings.prof.input_speed_args);
                 return;
             }
         }

--- a/driver/driver.cpp
+++ b/driver/driver.cpp
@@ -98,7 +98,7 @@ Arguments:
                     static_cast<double>(it->LastY)
                 };
 
-                devExt->mod.modify(input, devExt->mod_settings, devExt->dpi_factor, time);
+                devExt->mod.modify(input, devExt->speed_processor, devExt->mod_settings, devExt->dpi_factor, time);
 
                 double carried_result_x = input.x + devExt->carry.x;
                 double carried_result_y = input.y + devExt->carry.y;

--- a/driver/driver.h
+++ b/driver/driver.h
@@ -29,6 +29,7 @@ typedef struct _DEVICE_EXTENSION {
     vec2d carry;
     CONNECT_DATA UpperConnectData;
     ra::modifier_settings mod_settings;
+    ra::input_speed_processor speed_processor;
     WCHAR dev_id[ra::MAX_DEV_ID_LEN];
 } DEVICE_EXTENSION, *PDEVICE_EXTENSION;
 

--- a/driver/driver.h
+++ b/driver/driver.h
@@ -29,7 +29,7 @@ typedef struct _DEVICE_EXTENSION {
     vec2d carry;
     CONNECT_DATA UpperConnectData;
     ra::modifier_settings mod_settings;
-    ra::input_speed_processor speed_processor;
+    ra::speed_processor speed_processor;
     WCHAR dev_id[ra::MAX_DEV_ID_LEN];
 } DEVICE_EXTENSION, *PDEVICE_EXTENSION;
 

--- a/grapher/Form1.cs
+++ b/grapher/Form1.cs
@@ -57,7 +57,7 @@ namespace grapher
             {
                 var menuItem = new ToolStripMenuItem(colorScheme.Name);
 
-                menuItem.Checked = settings.CurrentColorScheme == colorScheme.Name;
+                menuItem.Checked = settings?.CurrentColorScheme == colorScheme.Name;
                 themeMenuItem.DropDownItems.Add(menuItem);
             }
 

--- a/grapher/Models/AccelGUI.cs
+++ b/grapher/Models/AccelGUI.cs
@@ -180,7 +180,7 @@ namespace grapher
 
         public void UpdateGraph()
         {
-            AccelCharts.Calculate(Settings.ActiveAccel, Settings.ActiveProfile);
+            AccelCharts.Calculate(Settings.ActiveAccelForGraphing, Settings.ActiveProfile);
             AccelCharts.Bind();
         }
 

--- a/grapher/Models/AccelGUI.cs
+++ b/grapher/Models/AccelGUI.cs
@@ -123,12 +123,12 @@ namespace grapher
 
             // TODO - separate sensitivity fields, add new label for ratio
             settings.yxSensRatio = ApplyOptions.YToXRatio.Value;
-            settings.combineMagnitudes = ApplyOptions.IsWhole;
+            settings.inputSpeedArgs.combineMagnitudes = ApplyOptions.IsWhole;
             ApplyOptions.SetArgsFromActiveValues(ref settings.argsX, ref settings.argsY);
 
             var (domWeights, lpNorm) = ApplyOptions.Directionality.GetDomainArgs();
             settings.domainXY = domWeights;
-            settings.lpNorm = lpNorm;
+            settings.inputSpeedArgs.lpNorm = lpNorm;
 
             settings.rangeXY = ApplyOptions.Directionality.GetRangeXY();
 

--- a/grapher/Models/Charts/ChartState/ChartStateManager.cs
+++ b/grapher/Models/Charts/ChartState/ChartStateManager.cs
@@ -53,7 +53,7 @@ namespace grapher.Models.Charts.ChartState
         {
             ChartState chartState;
 
-            if (settings.combineMagnitudes)
+            if (settings.inputSpeedArgs.combineMagnitudes)
             {
                 if (settings.yxSensRatio != 1 ||
                     settings.domainXY.x != settings.domainXY.y ||

--- a/grapher/Models/Options/ApplyOptions.cs
+++ b/grapher/Models/Options/ApplyOptions.cs
@@ -106,8 +106,8 @@ namespace grapher.Models.Options
             YToXRatio.SetActiveValue(settings.yxSensRatio);
             Rotation.SetActiveValue(settings.rotation);
             
-            WholeVectorCheckBox.Checked = settings.combineMagnitudes;
-            ByComponentVectorCheckBox.Checked = !settings.combineMagnitudes;
+            WholeVectorCheckBox.Checked = settings.inputSpeedArgs.combineMagnitudes;
+            ByComponentVectorCheckBox.Checked = !settings.inputSpeedArgs.combineMagnitudes;
             ByComponentVectorXYLock.Checked = settings.argsX.Equals(settings.argsY);
             OptionSetX.SetActiveValues(ref settings.argsX);
             OptionSetY.SetActiveValues(ref settings.argsY);

--- a/grapher/Models/Options/Directionality/DirectionalityOptions.cs
+++ b/grapher/Models/Options/Directionality/DirectionalityOptions.cs
@@ -104,9 +104,9 @@ namespace grapher.Models.Options.Directionality
             Domain.SetActiveValues(settings.domainXY.x, settings.domainXY.y);
             Range.SetActiveValues(settings.rangeXY.x, settings.rangeXY.y);
 
-            if (settings.combineMagnitudes)
+            if (settings.inputSpeedArgs.combineMagnitudes)
             {
-                LpNorm.SetActiveValue(settings.lpNorm);
+                LpNorm.SetActiveValue(settings.inputSpeedArgs.lpNorm);
             }
             else
             {

--- a/grapher/Models/Serialized/SettingsManager.cs
+++ b/grapher/Models/Serialized/SettingsManager.cs
@@ -89,8 +89,9 @@ namespace grapher.Models.Serialized
                 {
                     ActiveConfigField = value;
                     ActiveProfileNamesSet = new HashSet<string>(value.profiles.Select(p => p.name));
-                    ActiveAccelForGraphingField = value.accels[0].CreateStatelessCopy();
                 }
+
+                ActiveAccelForGraphingField = value.accels[0].CreateStatelessCopy();
             }
         }
 

--- a/grapher/Models/Serialized/SettingsManager.cs
+++ b/grapher/Models/Serialized/SettingsManager.cs
@@ -65,6 +65,8 @@ namespace grapher.Models.Serialized
         private DriverConfig ActiveConfigField;
         private DriverConfig UserConfigField;
 
+        private ManagedAccel ActiveAccelForGraphingField;
+
         #endregion Fields
 
         #region Properties
@@ -87,6 +89,7 @@ namespace grapher.Models.Serialized
                 {
                     ActiveConfigField = value;
                     ActiveProfileNamesSet = new HashSet<string>(value.profiles.Select(p => p.name));
+                    ActiveAccelForGraphingField = value.accels[0].CreateStatelessCopy();
                 }
             }
         }
@@ -100,6 +103,14 @@ namespace grapher.Models.Serialized
         public ManagedAccel ActiveAccel
         {
             get => ActiveConfig.accels[0];
+        }
+
+        /// <summary>
+        /// Version of active accel modified to be appropriate for graphing (stateless)
+        /// </summary>
+        public ManagedAccel ActiveAccelForGraphing
+        {
+            get => ActiveAccelForGraphingField;
         }
 
         public DriverConfig UserConfig 

--- a/installer/installer.vcxproj
+++ b/installer/installer.vcxproj
@@ -21,13 +21,13 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>

--- a/rawaccel.sln
+++ b/rawaccel.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.30104.148
+# Visual Studio Version 17
+VisualStudioVersion = 17.3.32929.385
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "driver", "driver\driver.vcxproj", "{60D6C942-AC20-4C05-A2BE-54B5C966534D}"
 EndProject
@@ -27,7 +27,97 @@ Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "converter", "converter\conv
 		{28A3656F-A1DE-405C-B547-191C32EC555F} = {28A3656F-A1DE-405C-B547-191C32EC555F}
 	EndProjectSection
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "wrapper-tests", "wrapper-tests\wrapper-tests.csproj", "{5DE4B0AC-D49B-43AE-B2B3-00C0A91D3C68}"
+EndProject
 Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Debug|x64 = Debug|x64
+		Release|Any CPU = Release|Any CPU
+		Release|x64 = Release|x64
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{60D6C942-AC20-4C05-A2BE-54B5C966534D}.Debug|Any CPU.ActiveCfg = Debug|x64
+		{60D6C942-AC20-4C05-A2BE-54B5C966534D}.Debug|Any CPU.Build.0 = Debug|x64
+		{60D6C942-AC20-4C05-A2BE-54B5C966534D}.Debug|Any CPU.Deploy.0 = Debug|x64
+		{60D6C942-AC20-4C05-A2BE-54B5C966534D}.Debug|x64.ActiveCfg = Debug|x64
+		{60D6C942-AC20-4C05-A2BE-54B5C966534D}.Debug|x64.Build.0 = Debug|x64
+		{60D6C942-AC20-4C05-A2BE-54B5C966534D}.Release|Any CPU.ActiveCfg = Release|x64
+		{60D6C942-AC20-4C05-A2BE-54B5C966534D}.Release|Any CPU.Build.0 = Release|x64
+		{60D6C942-AC20-4C05-A2BE-54B5C966534D}.Release|Any CPU.Deploy.0 = Release|x64
+		{60D6C942-AC20-4C05-A2BE-54B5C966534D}.Release|x64.ActiveCfg = Release|x64
+		{60D6C942-AC20-4C05-A2BE-54B5C966534D}.Release|x64.Build.0 = Release|x64
+		{896950D1-520A-420A-B6B1-73014B92A68C}.Debug|Any CPU.ActiveCfg = Debug|x64
+		{896950D1-520A-420A-B6B1-73014B92A68C}.Debug|Any CPU.Build.0 = Debug|x64
+		{896950D1-520A-420A-B6B1-73014B92A68C}.Debug|x64.ActiveCfg = Debug|x64
+		{896950D1-520A-420A-B6B1-73014B92A68C}.Debug|x64.Build.0 = Debug|x64
+		{896950D1-520A-420A-B6B1-73014B92A68C}.Release|Any CPU.ActiveCfg = Release|x64
+		{896950D1-520A-420A-B6B1-73014B92A68C}.Release|Any CPU.Build.0 = Release|x64
+		{896950D1-520A-420A-B6B1-73014B92A68C}.Release|x64.ActiveCfg = Release|x64
+		{896950D1-520A-420A-B6B1-73014B92A68C}.Release|x64.Build.0 = Release|x64
+		{A4097FF6-A6F0-44E8-B8D0-538D0FB75936}.Debug|Any CPU.ActiveCfg = Debug|x64
+		{A4097FF6-A6F0-44E8-B8D0-538D0FB75936}.Debug|Any CPU.Build.0 = Debug|x64
+		{A4097FF6-A6F0-44E8-B8D0-538D0FB75936}.Debug|x64.ActiveCfg = Debug|x64
+		{A4097FF6-A6F0-44E8-B8D0-538D0FB75936}.Debug|x64.Build.0 = Debug|x64
+		{A4097FF6-A6F0-44E8-B8D0-538D0FB75936}.Release|Any CPU.ActiveCfg = Release|x64
+		{A4097FF6-A6F0-44E8-B8D0-538D0FB75936}.Release|Any CPU.Build.0 = Release|x64
+		{A4097FF6-A6F0-44E8-B8D0-538D0FB75936}.Release|x64.ActiveCfg = Release|x64
+		{A4097FF6-A6F0-44E8-B8D0-538D0FB75936}.Release|x64.Build.0 = Release|x64
+		{28A3656F-A1DE-405C-B547-191C32EC555F}.Debug|Any CPU.ActiveCfg = Debug|x64
+		{28A3656F-A1DE-405C-B547-191C32EC555F}.Debug|Any CPU.Build.0 = Debug|x64
+		{28A3656F-A1DE-405C-B547-191C32EC555F}.Debug|x64.ActiveCfg = Debug|x64
+		{28A3656F-A1DE-405C-B547-191C32EC555F}.Debug|x64.Build.0 = Debug|x64
+		{28A3656F-A1DE-405C-B547-191C32EC555F}.Release|Any CPU.ActiveCfg = Release|x64
+		{28A3656F-A1DE-405C-B547-191C32EC555F}.Release|Any CPU.Build.0 = Release|x64
+		{28A3656F-A1DE-405C-B547-191C32EC555F}.Release|x64.ActiveCfg = Release|x64
+		{28A3656F-A1DE-405C-B547-191C32EC555F}.Release|x64.Build.0 = Release|x64
+		{EF67F71F-ABF5-4760-B50D-D1B9836DF01C}.Debug|Any CPU.ActiveCfg = Debug|x64
+		{EF67F71F-ABF5-4760-B50D-D1B9836DF01C}.Debug|Any CPU.Build.0 = Debug|x64
+		{EF67F71F-ABF5-4760-B50D-D1B9836DF01C}.Debug|x64.ActiveCfg = Debug|x64
+		{EF67F71F-ABF5-4760-B50D-D1B9836DF01C}.Debug|x64.Build.0 = Debug|x64
+		{EF67F71F-ABF5-4760-B50D-D1B9836DF01C}.Release|Any CPU.ActiveCfg = Release|x64
+		{EF67F71F-ABF5-4760-B50D-D1B9836DF01C}.Release|Any CPU.Build.0 = Release|x64
+		{EF67F71F-ABF5-4760-B50D-D1B9836DF01C}.Release|x64.ActiveCfg = Release|x64
+		{EF67F71F-ABF5-4760-B50D-D1B9836DF01C}.Release|x64.Build.0 = Release|x64
+		{28ACF254-E4EF-4A0E-9761-0FE22048D6FD}.Debug|Any CPU.ActiveCfg = Debug|x64
+		{28ACF254-E4EF-4A0E-9761-0FE22048D6FD}.Debug|Any CPU.Build.0 = Debug|x64
+		{28ACF254-E4EF-4A0E-9761-0FE22048D6FD}.Debug|x64.ActiveCfg = Debug|x64
+		{28ACF254-E4EF-4A0E-9761-0FE22048D6FD}.Debug|x64.Build.0 = Debug|x64
+		{28ACF254-E4EF-4A0E-9761-0FE22048D6FD}.Release|Any CPU.ActiveCfg = Release|x64
+		{28ACF254-E4EF-4A0E-9761-0FE22048D6FD}.Release|Any CPU.Build.0 = Release|x64
+		{28ACF254-E4EF-4A0E-9761-0FE22048D6FD}.Release|x64.ActiveCfg = Release|x64
+		{28ACF254-E4EF-4A0E-9761-0FE22048D6FD}.Release|x64.Build.0 = Release|x64
+		{0695A19E-8B14-4DE7-AADF-97E5912B197C}.Debug|Any CPU.ActiveCfg = Debug|x64
+		{0695A19E-8B14-4DE7-AADF-97E5912B197C}.Debug|Any CPU.Build.0 = Debug|x64
+		{0695A19E-8B14-4DE7-AADF-97E5912B197C}.Debug|x64.ActiveCfg = Debug|x64
+		{0695A19E-8B14-4DE7-AADF-97E5912B197C}.Debug|x64.Build.0 = Debug|x64
+		{0695A19E-8B14-4DE7-AADF-97E5912B197C}.Release|Any CPU.ActiveCfg = Release|x64
+		{0695A19E-8B14-4DE7-AADF-97E5912B197C}.Release|Any CPU.Build.0 = Release|x64
+		{0695A19E-8B14-4DE7-AADF-97E5912B197C}.Release|x64.ActiveCfg = Release|x64
+		{0695A19E-8B14-4DE7-AADF-97E5912B197C}.Release|x64.Build.0 = Release|x64
+		{4C421992-9A27-4860-A40C-ADD76FBACE55}.Debug|Any CPU.ActiveCfg = Debug|x64
+		{4C421992-9A27-4860-A40C-ADD76FBACE55}.Debug|Any CPU.Build.0 = Debug|x64
+		{4C421992-9A27-4860-A40C-ADD76FBACE55}.Debug|x64.ActiveCfg = Debug|x64
+		{4C421992-9A27-4860-A40C-ADD76FBACE55}.Debug|x64.Build.0 = Debug|x64
+		{4C421992-9A27-4860-A40C-ADD76FBACE55}.Release|Any CPU.ActiveCfg = Release|x64
+		{4C421992-9A27-4860-A40C-ADD76FBACE55}.Release|Any CPU.Build.0 = Release|x64
+		{4C421992-9A27-4860-A40C-ADD76FBACE55}.Release|x64.ActiveCfg = Release|x64
+		{4C421992-9A27-4860-A40C-ADD76FBACE55}.Release|x64.Build.0 = Release|x64
+		{5DE4B0AC-D49B-43AE-B2B3-00C0A91D3C68}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{5DE4B0AC-D49B-43AE-B2B3-00C0A91D3C68}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{5DE4B0AC-D49B-43AE-B2B3-00C0A91D3C68}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{5DE4B0AC-D49B-43AE-B2B3-00C0A91D3C68}.Debug|x64.Build.0 = Debug|Any CPU
+		{5DE4B0AC-D49B-43AE-B2B3-00C0A91D3C68}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{5DE4B0AC-D49B-43AE-B2B3-00C0A91D3C68}.Release|Any CPU.Build.0 = Release|Any CPU
+		{5DE4B0AC-D49B-43AE-B2B3-00C0A91D3C68}.Release|x64.ActiveCfg = Release|Any CPU
+		{5DE4B0AC-D49B-43AE-B2B3-00C0A91D3C68}.Release|x64.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {A3B5EC34-5340-4301-8BE9-33096EFEF77E}
+	EndGlobalSection
 	GlobalSection(SharedMSBuildProjectFiles) = preSolution
 		common\common.vcxitems*{24b4226f-1461-408f-a1a4-1371c97153ea}*SharedItemsImports = 9
 		common\common.vcxitems*{28a3656f-a1de-405c-b547-191c32ec555f}*SharedItemsImports = 4
@@ -35,49 +125,5 @@ Global
 		common\common.vcxitems*{60d6c942-ac20-4c05-a2be-54b5c966534d}*SharedItemsImports = 4
 		common\common.vcxitems*{896950d1-520a-420a-b6b1-73014b92a68c}*SharedItemsImports = 4
 		common\common.vcxitems*{a4097ff6-a6f0-44e8-b8d0-538d0fb75936}*SharedItemsImports = 4
-	EndGlobalSection
-	GlobalSection(SolutionConfigurationPlatforms) = preSolution
-		Debug|x64 = Debug|x64
-		Release|x64 = Release|x64
-	EndGlobalSection
-	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{60D6C942-AC20-4C05-A2BE-54B5C966534D}.Debug|x64.ActiveCfg = Debug|x64
-		{60D6C942-AC20-4C05-A2BE-54B5C966534D}.Debug|x64.Build.0 = Debug|x64
-		{60D6C942-AC20-4C05-A2BE-54B5C966534D}.Release|x64.ActiveCfg = Release|x64
-		{60D6C942-AC20-4C05-A2BE-54B5C966534D}.Release|x64.Build.0 = Release|x64
-		{896950D1-520A-420A-B6B1-73014B92A68C}.Debug|x64.ActiveCfg = Debug|x64
-		{896950D1-520A-420A-B6B1-73014B92A68C}.Debug|x64.Build.0 = Debug|x64
-		{896950D1-520A-420A-B6B1-73014B92A68C}.Release|x64.ActiveCfg = Release|x64
-		{896950D1-520A-420A-B6B1-73014B92A68C}.Release|x64.Build.0 = Release|x64
-		{A4097FF6-A6F0-44E8-B8D0-538D0FB75936}.Debug|x64.ActiveCfg = Debug|x64
-		{A4097FF6-A6F0-44E8-B8D0-538D0FB75936}.Debug|x64.Build.0 = Debug|x64
-		{A4097FF6-A6F0-44E8-B8D0-538D0FB75936}.Release|x64.ActiveCfg = Release|x64
-		{A4097FF6-A6F0-44E8-B8D0-538D0FB75936}.Release|x64.Build.0 = Release|x64
-		{28A3656F-A1DE-405C-B547-191C32EC555F}.Debug|x64.ActiveCfg = Debug|x64
-		{28A3656F-A1DE-405C-B547-191C32EC555F}.Debug|x64.Build.0 = Debug|x64
-		{28A3656F-A1DE-405C-B547-191C32EC555F}.Release|x64.ActiveCfg = Release|x64
-		{28A3656F-A1DE-405C-B547-191C32EC555F}.Release|x64.Build.0 = Release|x64
-		{EF67F71F-ABF5-4760-B50D-D1B9836DF01C}.Debug|x64.ActiveCfg = Debug|x64
-		{EF67F71F-ABF5-4760-B50D-D1B9836DF01C}.Debug|x64.Build.0 = Debug|x64
-		{EF67F71F-ABF5-4760-B50D-D1B9836DF01C}.Release|x64.ActiveCfg = Release|x64
-		{EF67F71F-ABF5-4760-B50D-D1B9836DF01C}.Release|x64.Build.0 = Release|x64
-		{28ACF254-E4EF-4A0E-9761-0FE22048D6FD}.Debug|x64.ActiveCfg = Debug|x64
-		{28ACF254-E4EF-4A0E-9761-0FE22048D6FD}.Debug|x64.Build.0 = Debug|x64
-		{28ACF254-E4EF-4A0E-9761-0FE22048D6FD}.Release|x64.ActiveCfg = Release|x64
-		{28ACF254-E4EF-4A0E-9761-0FE22048D6FD}.Release|x64.Build.0 = Release|x64
-		{0695A19E-8B14-4DE7-AADF-97E5912B197C}.Debug|x64.ActiveCfg = Debug|x64
-		{0695A19E-8B14-4DE7-AADF-97E5912B197C}.Debug|x64.Build.0 = Debug|x64
-		{0695A19E-8B14-4DE7-AADF-97E5912B197C}.Release|x64.ActiveCfg = Release|x64
-		{0695A19E-8B14-4DE7-AADF-97E5912B197C}.Release|x64.Build.0 = Release|x64
-		{4C421992-9A27-4860-A40C-ADD76FBACE55}.Debug|x64.ActiveCfg = Debug|x64
-		{4C421992-9A27-4860-A40C-ADD76FBACE55}.Debug|x64.Build.0 = Debug|x64
-		{4C421992-9A27-4860-A40C-ADD76FBACE55}.Release|x64.ActiveCfg = Release|x64
-		{4C421992-9A27-4860-A40C-ADD76FBACE55}.Release|x64.Build.0 = Release|x64
-	EndGlobalSection
-	GlobalSection(SolutionProperties) = preSolution
-		HideSolutionNode = FALSE
-	EndGlobalSection
-	GlobalSection(ExtensibilityGlobals) = postSolution
-		SolutionGuid = {A3B5EC34-5340-4301-8BE9-33096EFEF77E}
 	EndGlobalSection
 EndGlobal

--- a/uninstaller/uninstaller.vcxproj
+++ b/uninstaller/uninstaller.vcxproj
@@ -21,13 +21,13 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>

--- a/wrapper-tests/EndToEnd.cs
+++ b/wrapper-tests/EndToEnd.cs
@@ -1,0 +1,19 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace wrapper_tests
+{
+    [TestClass]
+    public class EndToEnd
+    {
+        [TestMethod]
+        public void ModifyInput_Default_DoesNotChangeInput()
+        {
+            var accel = new ManagedAccel();
+            (int x, int y) input = (1, 1);
+            var output = accel.Accelerate(input.x, input.y, 1, 1);
+
+            Assert.AreEqual(input.x, output.Item1);
+            Assert.AreEqual(input.y, output.Item2);
+        }
+    }
+}

--- a/wrapper-tests/EndToEndTests.cs
+++ b/wrapper-tests/EndToEndTests.cs
@@ -3,7 +3,7 @@
 namespace wrapper_tests
 {
     [TestClass]
-    public class EndToEnd
+    public class EndToEndTests
     {
         [TestMethod]
         public void ModifyInput_Default_DoesNotChangeInput()

--- a/wrapper-tests/Properties/AssemblyInfo.cs
+++ b/wrapper-tests/Properties/AssemblyInfo.cs
@@ -1,0 +1,20 @@
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+[assembly: AssemblyTitle("wrapper-tests")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("wrapper-tests")]
+[assembly: AssemblyCopyright("Copyright ©  2023")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+[assembly: ComVisible(false)]
+
+[assembly: Guid("5de4b0ac-d49b-43ae-b2b3-00c0a91d3c68")]
+
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/wrapper-tests/SpeedTests.cs
+++ b/wrapper-tests/SpeedTests.cs
@@ -68,6 +68,12 @@ namespace wrapper_tests
             double speed = 0;
             double sum = 0;
 
+            // saturate speed calculator's speed data
+            for (int i = 0; i < 100; i++)
+            {
+                speedCalc.CalculateSpeed(0, 0, 1);
+            }
+
             foreach (var input in inputs)
             {
                 speed = speedCalc.CalculateSpeed(input.Item1, input.Item2, 1);
@@ -102,7 +108,7 @@ namespace wrapper_tests
             {
                 inputs.Add((i, i));
 
-                if (i <= (cutoff_window + 1))
+                if (i <= cutoff_window)
                 {
                     cutoff_sum += Magnitude(i, i);
                 }

--- a/wrapper-tests/SpeedTests.cs
+++ b/wrapper-tests/SpeedTests.cs
@@ -45,20 +45,19 @@ namespace wrapper_tests
         [TestMethod]
         public void Given_InputForSimpleExponentialSmoothing_SmoothCalculator_Smooths()
         {
-            double smoothWindow = 100;
-            double averageAge = smoothWindow / 2.0;
+            double smoothHalfLife = 50;
             double pollTime = 1;
 
             var speedArgs = new SpeedCalculatorArgs(
                 lp_norm: 2,
                 should_smooth: true,
-                smooth_window: smoothWindow,
+                smooth_halflife: smoothHalfLife,
                 use_linear: false);
 
             var speedCalc = new SpeedCalculator();
             speedCalc.Init(speedArgs);
 
-            var modelSmoother = new SimpleExponentialSmoother(averageAge);
+            var modelSmoother = new SimpleExponentialSmoother(smoothHalfLife);
 
             var inputs = new[]
             {
@@ -86,20 +85,19 @@ namespace wrapper_tests
         [TestMethod]
         public void Given_InputForLinearExponentialSmoothing_SmoothCalculator_Smooths()
         {
-            double smoothWindow = 100;
-            double averageAge = smoothWindow / 2.0;
+            double smoothHalflife = 50;
             double pollTime = 1;
 
             var speedArgs = new SpeedCalculatorArgs(
                 lp_norm: 2,
                 should_smooth: true,
-                smooth_window: smoothWindow,
+                smooth_halflife: smoothHalflife,
                 use_linear: true);
 
             var speedCalc = new SpeedCalculator();
             speedCalc.Init(speedArgs);
 
-            var modelSmoother = new LinearExponentialSmoother(averageAge);
+            var modelSmoother = new LinearExponentialSmoother(smoothHalflife);
 
             var inputs = new[]
             {
@@ -136,9 +134,9 @@ namespace wrapper_tests
 
         protected class SimpleExponentialSmoother : IMouseSmoother
         {
-            public SimpleExponentialSmoother(double averageAge)
+            public SimpleExponentialSmoother(double halfLife)
             {
-                WindowCoefficient = Math.Pow(Math.E, (-1 / averageAge));
+                WindowCoefficient = Math.Pow(0.5, (1 / halfLife));
                 CutoffCoefficient = 1 - Math.Sqrt(1 - WindowCoefficient);
                 SmoothedSpeeds = new List<double>();
                 WindowTotal = 0;
@@ -168,12 +166,12 @@ namespace wrapper_tests
 
         protected class LinearExponentialSmoother : IMouseSmoother
         {
-            public const double TrendAverageAge = 2.5;
+            public const double TrendHalfLife = 1.25;
 
-            public LinearExponentialSmoother(double averageAge)
+            public LinearExponentialSmoother(double halfLife)
             {
-                WindowCoefficient = Math.Pow(Math.E, -1 / averageAge);
-                WindowTrendCoefficient = Math.Pow(Math.E, -1 / TrendAverageAge);
+                WindowCoefficient = Math.Pow(0.5, 1 / halfLife);
+                WindowTrendCoefficient = Math.Pow(0.5, 1 / TrendHalfLife);
                 CutoffCoefficient = 1 - Math.Sqrt(1 - WindowCoefficient);
                 CutoffTrendCoefficient = 1 - Math.Sqrt(1 - WindowTrendCoefficient);
                 SmoothedSpeeds = new List<double>();

--- a/wrapper-tests/SpeedTests.cs
+++ b/wrapper-tests/SpeedTests.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
+using System.Collections.Generic;
 
 namespace wrapper_tests
 {
@@ -15,9 +16,47 @@ namespace wrapper_tests
         }
         
         [TestMethod]
-        public void Given_Input_Smooths()
+        public void Given_Input_DefaultCalculator_ReturnsUnsmoothed()
         {
             var speedCalc = new SpeedCalculator();
+            var inputs = new[]
+            {
+                (0,0),
+                (1,1),
+                (2,2),
+                (3,3),
+            };
+
+            double timePerInput = 1;
+            double speed = 0;
+            double sum = 0;
+
+            foreach (var input in inputs)
+            {
+                speed = speedCalc.CalculateSpeed(input.Item1, input.Item2, timePerInput);
+                sum += Magnitude(input.Item1, input.Item2);
+            }
+
+            double expected = Magnitude(inputs[inputs.Length-1].Item1, inputs[inputs.Length-1].Item2) / timePerInput;
+
+            Assert.AreEqual(expected, speed, 0.0001);
+        }
+
+        [TestMethod]
+        public void Given_Input_SmoothCalculator_Smooths()
+        {
+            double smooth_window = 100;
+
+            var speedArgs = new SpeedCalculatorArgs(
+                lp_norm: 2,
+                should_smooth: true,
+                smooth_window: smooth_window,
+                should_cutoff: false,
+                cutoff_window: 0);
+
+            var speedCalc = new SpeedCalculator();
+            speedCalc.Init(speedArgs);
+
             var inputs = new[]
             {
                 (0,0),
@@ -35,9 +74,50 @@ namespace wrapper_tests
                 sum += Magnitude(input.Item1, input.Item2);
             }
 
-            double expected = sum / 100;
+            double expected = sum / smooth_window;
 
-            Assert.AreEqual(expected, speed);
+            Assert.AreEqual(expected, speed, 0.0001);
+        }
+
+        [TestMethod]
+        public void Given_InputWithCutoff_SmoothCalculator_Smooths()
+        {
+            double smooth_window = 100;
+            double cutoff_window = 10;
+
+            var speedArgs = new SpeedCalculatorArgs(
+                lp_norm: 2,
+                should_smooth: true,
+                smooth_window: smooth_window,
+                should_cutoff: true,
+                cutoff_window: cutoff_window);
+
+            var speedCalc = new SpeedCalculator();
+            speedCalc.Init(speedArgs);
+
+            var inputs = new List<(int, int)>();
+            double cutoff_sum = 0;
+
+            for (int i = 100; i > 0; i--)
+            {
+                inputs.Add((i, i));
+
+                if (i <= (cutoff_window + 1))
+                {
+                    cutoff_sum += Magnitude(i, i);
+                }
+            }
+
+            double speed = 0;
+
+            foreach (var input in inputs)
+            {
+                speed = speedCalc.CalculateSpeed(input.Item1, input.Item2, 1);
+            }
+
+            double expected = cutoff_sum / cutoff_window;
+
+            Assert.AreEqual(expected, speed, 0.0001);
         }
 
         public static double Magnitude (double x, double y)

--- a/wrapper-tests/SpeedTests.cs
+++ b/wrapper-tests/SpeedTests.cs
@@ -1,0 +1,48 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+
+namespace wrapper_tests
+{
+    [TestClass]
+    public class SpeedTests
+    {
+        [TestMethod]
+        public void Given_ZeroVector_ReturnsZero()
+        {
+            var speedCalc = new SpeedCalculator();
+            var speed = speedCalc.CalculateSpeed(0, 0, 1);
+            Assert.AreEqual(0, speed);
+        }
+        
+        [TestMethod]
+        public void Given_Input_Smooths()
+        {
+            var speedCalc = new SpeedCalculator();
+            var inputs = new[]
+            {
+                (0,0),
+                (1,1),
+                (2,2),
+                (3,3),
+            };
+
+            double speed = 0;
+            double sum = 0;
+
+            foreach (var input in inputs)
+            {
+                speed = speedCalc.CalculateSpeed(input.Item1, input.Item2, 1);
+                sum += Magnitude(input.Item1, input.Item2);
+            }
+
+            double expected = sum / 100;
+
+            Assert.AreEqual(expected, speed);
+        }
+
+        public static double Magnitude (double x, double y)
+        {
+            return Math.Sqrt(x * x + y * y);
+        }
+    }
+}

--- a/wrapper-tests/packages.config
+++ b/wrapper-tests/packages.config
@@ -1,0 +1,5 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="MSTest.TestAdapter" version="2.2.7" targetFramework="net472" />
+  <package id="MSTest.TestFramework" version="2.2.7" targetFramework="net472" />
+</packages>

--- a/wrapper-tests/wrapper-tests.csproj
+++ b/wrapper-tests/wrapper-tests.csproj
@@ -50,8 +50,9 @@
     <Reference Include="System.Core" />
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="EndToEnd.cs" />
+    <Compile Include="EndToEndTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="SpeedTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />

--- a/wrapper-tests/wrapper-tests.csproj
+++ b/wrapper-tests/wrapper-tests.csproj
@@ -1,0 +1,75 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\packages\MSTest.TestAdapter.2.2.7\build\net45\MSTest.TestAdapter.props" Condition="Exists('..\packages\MSTest.TestAdapter.2.2.7\build\net45\MSTest.TestAdapter.props')" />
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{5DE4B0AC-D49B-43AE-B2B3-00C0A91D3C68}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>wrapper_tests</RootNamespace>
+    <AssemblyName>wrapper-tests</AssemblyName>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">15.0</VisualStudioVersion>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+    <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\$(VisualStudioVersion)\UITestExtensionPackages</ReferencePath>
+    <IsCodedUITest>False</IsCodedUITest>
+    <TestProjectType>UnitTest</TestProjectType>
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <PlatformTarget>x64</PlatformTarget>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="Microsoft.VisualStudio.TestPlatform.TestFramework, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\MSTest.TestFramework.2.2.7\lib\net45\Microsoft.VisualStudio.TestPlatform.TestFramework.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.VisualStudio.TestPlatform.TestFramework.Extensions, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\MSTest.TestFramework.2.2.7\lib\net45\Microsoft.VisualStudio.TestPlatform.TestFramework.Extensions.dll</HintPath>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="EndToEnd.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\wrapper\wrapper.vcxproj">
+      <Project>{28a3656f-a1de-405c-b547-191c32ec555f}</Project>
+      <Name>wrapper</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets" Condition="Exists('$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets')" />
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\packages\MSTest.TestAdapter.2.2.7\build\net45\MSTest.TestAdapter.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\MSTest.TestAdapter.2.2.7\build\net45\MSTest.TestAdapter.props'))" />
+    <Error Condition="!Exists('..\packages\MSTest.TestAdapter.2.2.7\build\net45\MSTest.TestAdapter.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\MSTest.TestAdapter.2.2.7\build\net45\MSTest.TestAdapter.targets'))" />
+  </Target>
+  <Import Project="..\packages\MSTest.TestAdapter.2.2.7\build\net45\MSTest.TestAdapter.targets" Condition="Exists('..\packages\MSTest.TestAdapter.2.2.7\build\net45\MSTest.TestAdapter.targets')" />
+</Project>

--- a/wrapper/wrapper.cpp
+++ b/wrapper/wrapper.cpp
@@ -458,6 +458,22 @@ public:
         delete instance;
     }
 
+    /// <summary>
+    /// The modifier inside of ManagedAccel is now stateful, which can result in strange graphs when used for graphing purposes.
+    /// This method creates a copy of its instance with any stateful elements turned off.
+    /// </summary>
+    /// <returns></returns>
+    ManagedAccel^ CreateStatelessCopy()
+    {
+        Profile^ profile = Settings;
+
+        profile->inputSpeedArgs.inputSmoothHalflife = 0;
+        profile->inputSpeedArgs.scaleSmoothHalflife = 0;
+        profile->inputSpeedArgs.outputSmoothHalflife = 0;
+
+        return gcnew ManagedAccel(profile);
+    }
+
     Tuple<double, double>^ Accelerate(int x, int y, double dpi_factor, double time)
     {
         vec2d in_out_vec = {

--- a/wrapper/wrapper.cpp
+++ b/wrapper/wrapper.cpp
@@ -111,8 +111,8 @@ public value struct InputSpeedArgs
     [MarshalAs(UnmanagedType::U1)]
     bool shouldSmooth;
 
-    [JsonProperty("Time window in ms over which input should be smoothed")]
-	double smoothWindow;
+    [JsonProperty("Time in ms after which an input is weighted at half its original value.")]
+	double smoothHalfLife;
 
     [JsonProperty("Whether smoothed input speeds should use linear (true) or simple (false) exponential smoothing")]
     [MarshalAs(UnmanagedType::U1)]
@@ -498,11 +498,11 @@ public:
     SpeedCalculatorArgs(
         double lp_norm,
         bool should_smooth,
-        double smooth_window,
+        double smooth_halflife,
         bool use_linear)
     {
         speed_args->lp_norm = lp_norm;
-        speed_args->smooth_window = smooth_window;
+        speed_args->smooth_halflife = smooth_halflife;
         speed_args->should_smooth = should_smooth;
         speed_args->use_linear = use_linear;
     }

--- a/wrapper/wrapper.cpp
+++ b/wrapper/wrapper.cpp
@@ -524,17 +524,17 @@ public:
     double CalculateSpeed(double x, double y, double time)
     {
         vec2d in = { x ,y };
-        return instance->speed_calculator.calc_speed(in, time);
+        return instance->speed_calculator.calc_speed_whole(in, time);
     }
 
     double SmoothScale(double scale, double time)
     {
-        return instance->speed_calculator.scale_smoother.smooth(scale, time);
+        return instance->speed_calculator.smoother_x.scale_smoother.smooth(scale, time);
     }
 
     double SmoothOutput(double outputSpeed, double time)
     {
-        return instance->speed_calculator.output_speed_smoother.smooth(outputSpeed, time);
+        return instance->speed_calculator.smoother_x.output_speed_smoother.smooth(outputSpeed, time);
     }
 };
 

--- a/wrapper/wrapper.cpp
+++ b/wrapper/wrapper.cpp
@@ -119,7 +119,7 @@ public value struct InputSpeedArgs
     bool shouldCutoff;
 
     [JsonProperty("Time window in ms over which cutoff speed is calculated")]
-    float cutoffWindow;
+    double cutoffWindow;
 };
 
 [JsonObject(ItemRequired = Required::Always)]

--- a/wrapper/wrapper.cpp
+++ b/wrapper/wrapper.cpp
@@ -411,9 +411,15 @@ struct accel_instance_t {
     }
 };
 
+struct speed_calc_instance_t
+{
+    ra::input_speed_processor speed_calculator = {};
+};
+
 public ref class ManagedAccel
 {
     accel_instance_t* const instance = new accel_instance_t();
+    speed_calc_instance_t* const speed_instance = new speed_calc_instance_t();
 public:
 
     ManagedAccel() {}
@@ -443,7 +449,7 @@ public:
             (double)y
         };
 
-        instance->mod.modify(in_out_vec, instance->settings, dpi_factor, time);
+        instance->mod.modify(in_out_vec, speed_instance->speed_calculator, instance->settings, dpi_factor, time);
 
         return gcnew Tuple<double, double>(in_out_vec.x, in_out_vec.y);
     }
@@ -466,7 +472,19 @@ public:
     {
         return instance->settings;
     }
+};
 
+public ref class SpeedCalculator
+{
+    speed_calc_instance_t* const instance = new speed_calc_instance_t();
+public:
+    SpeedCalculator() {}
+
+    double CalculateSpeed(double x, double y, double time)
+    {
+        vec2d in = { x ,y };
+        return instance->speed_calculator.calc_speed(in, ra::distance_mode::euclidean, 2);
+    }
 };
 
 

--- a/wrapper/wrapper.cpp
+++ b/wrapper/wrapper.cpp
@@ -114,12 +114,9 @@ public value struct InputSpeedArgs
     [JsonProperty("Time window in ms over which input should be smoothed")]
 	double smoothWindow;
 
-    [JsonProperty("Whether smoothed input speeds should stop smoothing and take latest speed when latest speed is lower")]
+    [JsonProperty("Whether smoothed input speeds should use linear (true) or simple (false) exponential smoothing")]
     [MarshalAs(UnmanagedType::U1)]
-    bool shouldCutoff;
-
-    [JsonProperty("Time window in ms over which cutoff speed is calculated")]
-    double cutoffWindow;
+    bool useLinear;
 };
 
 [JsonObject(ItemRequired = Required::Always)]
@@ -502,14 +499,12 @@ public:
         double lp_norm,
         bool should_smooth,
         double smooth_window,
-        bool should_cutoff,
-        double cutoff_window)
+        bool use_linear)
     {
         speed_args->lp_norm = lp_norm;
         speed_args->smooth_window = smooth_window;
         speed_args->should_smooth = should_smooth;
-        speed_args->use_cutoff = should_cutoff;
-        speed_args->cutoff_window = cutoff_window;
+        speed_args->use_linear = use_linear;
     }
 
     ra::input_speed_args* const speed_args = new ra::input_speed_args();

--- a/wrapper/wrapper.vcxproj
+++ b/wrapper/wrapper.vcxproj
@@ -22,14 +22,14 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <CLRSupport>true</CLRSupport>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <CLRSupport>true</CLRSupport>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>


### PR DESCRIPTION
This pull request adds the following:

- Linear and Simple Exponential Moving Average (EMA) calculators for use in smoothing
- Speed processor which uses above smoothers to smooth input to accel function (linear EMA), output scale of accel function (simple EMA), and full output from program (output EMA)
    - (Of those three, only full output causes a "motion delay" between user moving mouse and mouse cursor moving. Other two only smooth the acceleration applied.) 
- Unit tests to ensure some basic functionality, and that the above smoothers work as expected
- Three new entries in the settings.json which represent the half-life weighting of input, scale, output smoothing. Half-life of 0 indicates no smoothing will occur.
- Moves solution to VS 22
- Tweak to grapher to ensure state within accelerator does not affect graphs
- Various small fixes