### PR TITLE
[Code] Change mentions of sensitivity to output dpi

### DIFF
--- a/common/accel-power.hpp
+++ b/common/accel-power.hpp
@@ -30,7 +30,7 @@ namespace rawaccel {
 				*/
 				offset = {};
 				constant = 0;
-				scale = scale_from_sens_point(args.cap.x, args.cap.y, n, constant);
+				scale = scale_from_output_point(args.cap.x, args.cap.y, n, constant);
 				return;
 			}
 
@@ -64,9 +64,9 @@ namespace rawaccel {
 			return pow(gain / (power + 1), 1 / power) / input;
 		}
 
-		static double scale_from_sens_point(double input, double sens, double power, double C)
+		static double scale_from_output_point(double input, double output, double power, double C)
 		{
-			return pow(sens - C / input, 1 / power) / input;
+			return pow(output - C / input, 1 / power) / input;
 		}
 	};
 

--- a/common/rawaccel-base.hpp
+++ b/common/rawaccel-base.hpp
@@ -21,6 +21,9 @@ namespace rawaccel {
 
     inline constexpr double MAX_NORM = 16;
 
+    // At this DPI, one count per ms equals one inch per second.
+    inline constexpr double NORMALIZED_DPI = 1000;
+
     inline constexpr bool LEGACY = 0;
     inline constexpr bool GAIN = 1;
     
@@ -71,7 +74,6 @@ namespace rawaccel {
         double output_speed_smooth_halflife = 0;
     };
 
-
     struct profile {
         wchar_t name[MAX_NAME_LEN] = L"default";
 
@@ -82,7 +84,7 @@ namespace rawaccel {
         accel_args accel_y;
         speed_args speed_processor_args;
 
-        double sensitivity = 1;
+        double output_dpi = NORMALIZED_DPI;
         double yx_sens_ratio = 1;
         double lr_sens_ratio = 1;
         double ud_sens_ratio = 1;
@@ -94,6 +96,4 @@ namespace rawaccel {
         double speed_min = 0;
         double speed_max = 0;
     };
-
-
 }

--- a/common/rawaccel-base.hpp
+++ b/common/rawaccel-base.hpp
@@ -85,9 +85,9 @@ namespace rawaccel {
         speed_args speed_processor_args;
 
         double output_dpi = NORMALIZED_DPI;
-        double yx_sens_ratio = 1;
-        double lr_sens_ratio = 1;
-        double ud_sens_ratio = 1;
+        double yx_output_dpi_ratio = 1;
+        double lr_output_dpi_ratio = 1;
+        double ud_output_dpi_ratio = 1;
 
         double degrees_rotation = 0;
 

--- a/common/rawaccel-validate.hpp
+++ b/common/rawaccel-validate.hpp
@@ -154,11 +154,11 @@ namespace rawaccel {
 		}
 
 		if (args.output_dpi == 0) {
-			error("sens multiplier is 0");
+			error("output DPI is 0");
 		}
 	
-		if (args.yx_sens_ratio == 0) {
-			error("Y/X sens ratio is 0");
+		if (args.yx_output_dpi_ratio == 0) {
+			error("Y/X output DPI ratio is 0");
 		}
 
 		if (args.domain_weights.x <= 0 ||
@@ -166,8 +166,8 @@ namespace rawaccel {
 			error("domain weights"" must be positive");
 		}
 
-		if (args.lr_sens_ratio <= 0 || args.ud_sens_ratio <= 0) {
-			error("sens ratio must be positive");
+		if (args.lr_output_dpi_ratio <= 0 || args.ud_output_dpi_ratio <= 0) {
+			error("output DPI ratio must be positive");
 		}
 
 		if (args.speed_processor_args.lp_norm <= 0) {

--- a/common/rawaccel-validate.hpp
+++ b/common/rawaccel-validate.hpp
@@ -153,7 +153,7 @@ namespace rawaccel {
 			error("snap angle must be between 0 and 45 degrees");
 		}
 
-		if (args.sensitivity == 0) {
+		if (args.output_dpi == 0) {
 			error("sens multiplier is 0");
 		}
 	

--- a/common/rawaccel.hpp
+++ b/common/rawaccel.hpp
@@ -49,8 +49,8 @@ namespace rawaccel {
             apply_directional_weight = args.speed_processor_args.whole && 
                 args.range_weights.x != args.range_weights.y;
             compute_ref_angle = apply_snap || apply_directional_weight;
-            apply_dir_mul_x = args.lr_sens_ratio != 1;
-            apply_dir_mul_y = args.ud_sens_ratio != 1;
+            apply_dir_mul_x = args.lr_output_dpi_ratio != 1;
+            apply_dir_mul_y = args.ud_output_dpi_ratio != 1;
         }
 
         modifier_flags() = default;
@@ -411,14 +411,14 @@ namespace rawaccel {
 
             double dpi_adjustment = output_dpi_adjustment_factor * dpi_factor;
             in.x *= dpi_adjustment;
-            in.y *= dpi_adjustment * args.yx_sens_ratio;
+            in.y *= dpi_adjustment * args.yx_output_dpi_ratio;
 
             if (flags.apply_dir_mul_x && in.x < 0) {
-                in.x *= args.lr_sens_ratio;
+                in.x *= args.lr_output_dpi_ratio;
             }
 
             if (flags.apply_dir_mul_y && in.y < 0) {
-                in.y *= args.ud_sens_ratio;
+                in.y *= args.ud_output_dpi_ratio;
             }
 
         }

--- a/common/rawaccel.hpp
+++ b/common/rawaccel.hpp
@@ -409,9 +409,9 @@ namespace rawaccel {
                 }
             }
 
-            double dpi_adjusted_sens = args.sensitivity * dpi_factor;
-            in.x *= dpi_adjusted_sens;
-            in.y *= dpi_adjusted_sens * args.yx_sens_ratio;
+            double dpi_adjustment = output_dpi_adjustment_factor * dpi_factor;
+            in.x *= dpi_adjustment;
+            in.y *= dpi_adjustment * args.yx_sens_ratio;
 
             if (flags.apply_dir_mul_x && in.x < 0) {
                 in.x *= args.lr_sens_ratio;
@@ -427,6 +427,7 @@ namespace rawaccel {
         {
             set_callback(cb_x, settings.data.accel_x, settings.prof.accel_x);
             set_callback(cb_y, settings.data.accel_y, settings.prof.accel_y);
+            output_dpi_adjustment_factor = settings.prof.output_dpi / NORMALIZED_DPI;
         }
 
         modifier() = default;
@@ -453,6 +454,8 @@ namespace rawaccel {
 
         callback_t cb_x = &callback_template<accel_noaccel>;
         callback_t cb_y = &callback_template<accel_noaccel>;
+
+        double output_dpi_adjustment_factor = 1;
     };
 
 } // rawaccel

--- a/driver/driver.cpp
+++ b/driver/driver.cpp
@@ -110,7 +110,7 @@ Arguments:
                     static_cast<double>(it->LastY)
                 };
 
-                devExt->mod.modify(input, devExt->speed_processor, devExt->mod_settings, devExt->input_dpi_factor, time);
+                devExt->mod.modify(input, devExt->speed_processor, devExt->mod_settings, devExt->input_dpi_normalization_factor, time);
 
                 double carried_result_x = input.x + devExt->carry.x;
                 double carried_result_y = input.y + devExt->carry.y;
@@ -373,7 +373,7 @@ DeviceSetup(WDFOBJECT hDevice)
     auto set_ext_from_cfg = [devExt](const ra::device_config& cfg) {
         devExt->enable = !cfg.disable;
         devExt->set_extra_info = cfg.set_extra_info;
-        devExt->input_dpi_factor = (cfg.dpi > 0) ? (1000.0 / cfg.dpi) : 1;
+        devExt->input_dpi_normalization_factor = (cfg.dpi > 0) ? (ra::NORMALIZED_DPI / cfg.dpi) : 1;
 
         bool rate_given = cfg.polling_rate > 0;
 

--- a/driver/driver.cpp
+++ b/driver/driver.cpp
@@ -110,7 +110,7 @@ Arguments:
                     static_cast<double>(it->LastY)
                 };
 
-                devExt->mod.modify(input, devExt->speed_processor, devExt->mod_settings, devExt->dpi_factor, time);
+                devExt->mod.modify(input, devExt->speed_processor, devExt->mod_settings, devExt->input_dpi_factor, time);
 
                 double carried_result_x = input.x + devExt->carry.x;
                 double carried_result_y = input.y + devExt->carry.y;
@@ -373,7 +373,7 @@ DeviceSetup(WDFOBJECT hDevice)
     auto set_ext_from_cfg = [devExt](const ra::device_config& cfg) {
         devExt->enable = !cfg.disable;
         devExt->set_extra_info = cfg.set_extra_info;
-        devExt->dpi_factor = (cfg.dpi > 0) ? (1000.0 / cfg.dpi) : 1;
+        devExt->input_dpi_factor = (cfg.dpi > 0) ? (1000.0 / cfg.dpi) : 1;
 
         bool rate_given = cfg.polling_rate > 0;
 

--- a/driver/driver.h
+++ b/driver/driver.h
@@ -22,7 +22,7 @@ typedef struct _DEVICE_EXTENSION {
     bool enable;
     bool keep_time;
     bool set_extra_info;
-    double input_dpi_factor;
+    double input_dpi_normalization_factor;
     counter_t counter;
     ra::time_clamp clamp;
     ra::modifier mod;

--- a/driver/driver.h
+++ b/driver/driver.h
@@ -22,7 +22,7 @@ typedef struct _DEVICE_EXTENSION {
     bool enable;
     bool keep_time;
     bool set_extra_info;
-    double dpi_factor;
+    double input_dpi_factor;
     counter_t counter;
     ra::time_clamp clamp;
     ra::modifier mod;

--- a/grapher/Common/Constants.cs
+++ b/grapher/Common/Constants.cs
@@ -1,7 +1,7 @@
 ﻿using System.Drawing;
 using System.Globalization;
 
-namespace grapher
+namespace grapher.Common
 {
     public static class Constants
     {

--- a/grapher/Common/Helper.cs
+++ b/grapher/Common/Helper.cs
@@ -1,0 +1,11 @@
+﻿namespace grapher.Common
+{
+    public static class Helper
+    {
+        public static double GetSensitivityFactor(Profile profile) => GetSensitivityFactor(profile.outputDPI);
+
+        public static double GetSensitivityFactor(double outputDPI) => outputDPI / Constants.DriverNormalizedDPI;
+
+        public static double CalculatOutputDPI(double sensitivity) => sensitivity * Constants.DriverNormalizedDPI;
+    }
+}

--- a/grapher/Constants/Constants.cs
+++ b/grapher/Constants/Constants.cs
@@ -8,10 +8,10 @@ namespace grapher
         #region Constants
 
         /// <summary> DPI by which charts are scaled if none is set by user. </summary>
-        public const int DefaultDPI = 1200;
+        public const int DefaultChartsScalingDPI = 1200;
 
         /// <summary> Poll rate by which charts are scaled if none is set by user. </summary>
-        public const int DefaultPollRate = 1000;
+        public const int DefaultChartsScalingPollRate = 1000;
 
         /// <summary> Resolution of chart calulation. </summary>
         public const int Resolution = 500;
@@ -145,6 +145,9 @@ namespace grapher
 
         /// <summary> Line Width For Series data on chart </summary>
         public const int ChartSeriesLineWidth = 3;
+
+        /// <summary> DPI to which driver is normalizing inputs </summary>
+        public const double DriverNormalizedDPI = 1000.0;
         #endregion Constants
 
         #region ReadOnly

--- a/grapher/Form1.cs
+++ b/grapher/Form1.cs
@@ -8,6 +8,7 @@ using grapher.Models;
 using System.IO;
 using grapher.Models.Serialized;
 using grapher.Models.Theming;
+using grapher.Common;
 
 namespace grapher
 {

--- a/grapher/Models/AccelGUI.cs
+++ b/grapher/Models/AccelGUI.cs
@@ -123,7 +123,7 @@ namespace grapher
             settings.outputDPI = Helper.CalculatOutputDPI(ApplyOptions.Sensitivity.Field.Data);
 
             // TODO - separate sensitivity fields, add new label for ratio
-            settings.yxSensRatio = ApplyOptions.YToXRatio.Value;
+            settings.yxOutputDPIRatio = ApplyOptions.YToXRatio.Value;
             settings.inputSpeedArgs.combineMagnitudes = ApplyOptions.IsWhole;
             ApplyOptions.SetArgsFromActiveValues(ref settings.argsX, ref settings.argsY);
 

--- a/grapher/Models/AccelGUI.cs
+++ b/grapher/Models/AccelGUI.cs
@@ -119,7 +119,7 @@ namespace grapher
             var settings = new Profile();
 
             settings.rotation = ApplyOptions.Rotation.Field.Data;
-            settings.sensitivity = ApplyOptions.Sensitivity.Field.Data;
+            settings.outputDPI = ApplyOptions.Sensitivity.Field.Data * 1000;
 
             // TODO - separate sensitivity fields, add new label for ratio
             settings.yxSensRatio = ApplyOptions.YToXRatio.Value;

--- a/grapher/Models/AccelGUI.cs
+++ b/grapher/Models/AccelGUI.cs
@@ -120,7 +120,7 @@ namespace grapher
             var settings = new Profile();
 
             settings.rotation = ApplyOptions.Rotation.Field.Data;
-            settings.outputDPI = ApplyOptions.Sensitivity.Field.Data * 1000;
+            settings.outputDPI = Helper.CalculatOutputDPI(ApplyOptions.Sensitivity.Field.Data);
 
             // TODO - separate sensitivity fields, add new label for ratio
             settings.yxSensRatio = ApplyOptions.YToXRatio.Value;

--- a/grapher/Models/AccelGUI.cs
+++ b/grapher/Models/AccelGUI.cs
@@ -1,4 +1,5 @@
-﻿using grapher.Models.Calculations;
+﻿using grapher.Common;
+using grapher.Models.Calculations;
 using grapher.Models.Devices;
 using grapher.Models.Mouse;
 using grapher.Models.Options;

--- a/grapher/Models/AccelGUIFactory.cs
+++ b/grapher/Models/AccelGUIFactory.cs
@@ -213,8 +213,8 @@ namespace grapher.Models
             fakeBox.Hide();
 
             var accelCalculator = new AccelCalculator(
-                new Field(dpiTextBox.TextBox, form, Constants.DefaultDPI, 1),
-                new Field(pollRateTextBox.TextBox, form, Constants.DefaultPollRate, 1));
+                new Field(dpiTextBox.TextBox, form, Constants.DefaultChartsScalingDPI, 1),
+                new Field(pollRateTextBox.TextBox, form, Constants.DefaultChartsScalingPollRate, 1));
 
             var accelCharts = new AccelCharts(
                                 form,

--- a/grapher/Models/AccelGUIFactory.cs
+++ b/grapher/Models/AccelGUIFactory.cs
@@ -10,6 +10,7 @@ using System;
 using System.Windows.Forms;
 using System.Windows.Forms.DataVisualization.Charting;
 using grapher.Models.Theming.Controls;
+using grapher.Common;
 
 namespace grapher.Models
 {

--- a/grapher/Models/Calculations/AccelCalculator.cs
+++ b/grapher/Models/Calculations/AccelCalculator.cs
@@ -247,7 +247,7 @@ namespace grapher.Models.Calculations
                     }
 
                     var ratio = DecimalCheck(magnitude / simulatedInputDatum.velocity);
-                    var slope = DecimalCheck(inDiff > 0 ? outDiff / inDiff : settings.outputDPI / Constants.DriverNormalizedDPI);
+                    var slope = DecimalCheck(inDiff > 0 ? outDiff / inDiff : Helper.GetSensitivityFactor(settings));
 
                     bool indexToMeasureExtrema = (angleIndex == 0) || (angleIndex == (Constants.AngleDivisions - 1));
                     
@@ -484,8 +484,11 @@ namespace grapher.Models.Calculations
         public static bool ShouldStripRot(Profile settings) =>
             settings.rotation > 0;
 
-        public static (double, double) GetSens(Profile settings) =>
-            (settings.outputDPI / Constants.DriverNormalizedDPI, settings.outputDPI * settings.yxSensRatio / Constants.DriverNormalizedDPI);
+        public static (double, double) GetSens(Profile settings)
+        {
+            var sensFactor = Helper.GetSensitivityFactor(settings); 
+            return (sensFactor, sensFactor * settings.yxSensRatio);
+        }
 
         public static (double, double) GetRotVector(Profile settings) =>
             (Math.Cos(settings.rotation), Math.Sin(settings.rotation));

--- a/grapher/Models/Calculations/AccelCalculator.cs
+++ b/grapher/Models/Calculations/AccelCalculator.cs
@@ -246,7 +246,7 @@ namespace grapher.Models.Calculations
                     }
 
                     var ratio = DecimalCheck(magnitude / simulatedInputDatum.velocity);
-                    var slope = DecimalCheck(inDiff > 0 ? outDiff / inDiff : settings.outputDPI / 1000.0);
+                    var slope = DecimalCheck(inDiff > 0 ? outDiff / inDiff : settings.outputDPI / Constants.DriverNormalizedDPI);
 
                     bool indexToMeasureExtrema = (angleIndex == 0) || (angleIndex == (Constants.AngleDivisions - 1));
                     
@@ -484,7 +484,7 @@ namespace grapher.Models.Calculations
             settings.rotation > 0;
 
         public static (double, double) GetSens(Profile settings) =>
-            (settings.outputDPI / 1000.0, settings.outputDPI * settings.yxSensRatio / 1000.0);
+            (settings.outputDPI / Constants.DriverNormalizedDPI, settings.outputDPI * settings.yxSensRatio / Constants.DriverNormalizedDPI);
 
         public static (double, double) GetRotVector(Profile settings) =>
             (Math.Cos(settings.rotation), Math.Sin(settings.rotation));

--- a/grapher/Models/Calculations/AccelCalculator.cs
+++ b/grapher/Models/Calculations/AccelCalculator.cs
@@ -479,7 +479,7 @@ namespace grapher.Models.Calculations
         }
 
         public static bool ShouldStripSens(Profile settings) =>
-            settings.yxSensRatio != 1;
+            settings.yxOutputDPIRatio != 1;
 
         public static bool ShouldStripRot(Profile settings) =>
             settings.rotation > 0;
@@ -487,7 +487,7 @@ namespace grapher.Models.Calculations
         public static (double, double) GetSens(Profile settings)
         {
             var sensFactor = Helper.GetSensitivityFactor(settings); 
-            return (sensFactor, sensFactor * settings.yxSensRatio);
+            return (sensFactor, sensFactor * settings.yxOutputDPIRatio);
         }
 
         public static (double, double) GetRotVector(Profile settings) =>

--- a/grapher/Models/Calculations/AccelCalculator.cs
+++ b/grapher/Models/Calculations/AccelCalculator.cs
@@ -246,7 +246,7 @@ namespace grapher.Models.Calculations
                     }
 
                     var ratio = DecimalCheck(magnitude / simulatedInputDatum.velocity);
-                    var slope = DecimalCheck(inDiff > 0 ? outDiff / inDiff : settings.sensitivity);
+                    var slope = DecimalCheck(inDiff > 0 ? outDiff / inDiff : settings.outputDPI / 1000.0);
 
                     bool indexToMeasureExtrema = (angleIndex == 0) || (angleIndex == (Constants.AngleDivisions - 1));
                     
@@ -484,7 +484,7 @@ namespace grapher.Models.Calculations
             settings.rotation > 0;
 
         public static (double, double) GetSens(Profile settings) =>
-            (settings.sensitivity, settings.sensitivity * settings.yxSensRatio);
+            (settings.outputDPI / 1000.0, settings.outputDPI * settings.yxSensRatio / 1000.0);
 
         public static (double, double) GetRotVector(Profile settings) =>
             (Math.Cos(settings.rotation), Math.Sin(settings.rotation));

--- a/grapher/Models/Calculations/AccelCalculator.cs
+++ b/grapher/Models/Calculations/AccelCalculator.cs
@@ -1,4 +1,5 @@
-﻿using grapher.Models.Serialized;
+﻿using grapher.Common;
+using grapher.Models.Serialized;
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;

--- a/grapher/Models/Calculations/Data/AccelDataCombined.cs
+++ b/grapher/Models/Calculations/Data/AccelDataCombined.cs
@@ -1,4 +1,5 @@
-﻿using grapher.Models.Charts;
+﻿using grapher.Common;
+using grapher.Models.Charts;
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/grapher/Models/Calculations/Data/AccelDataCombined.cs
+++ b/grapher/Models/Calculations/Data/AccelDataCombined.cs
@@ -44,7 +44,7 @@ namespace grapher.Models.Calculations.Data
         public void CreateGraphData(ManagedAccel accel, Profile settings)
         {
             Clear();
-            Calculator.Calculate(X, accel, settings.outputDPI / Constants.DriverNormalizedDPI, Calculator.SimulatedInputCombined);
+            Calculator.Calculate(X, accel, Helper.GetSensitivityFactor(settings), Calculator.SimulatedInputCombined);
         }
     }
 }

--- a/grapher/Models/Calculations/Data/AccelDataCombined.cs
+++ b/grapher/Models/Calculations/Data/AccelDataCombined.cs
@@ -43,7 +43,7 @@ namespace grapher.Models.Calculations.Data
         public void CreateGraphData(ManagedAccel accel, Profile settings)
         {
             Clear();
-            Calculator.Calculate(X, accel, settings.outputDPI / 1000.0, Calculator.SimulatedInputCombined);
+            Calculator.Calculate(X, accel, settings.outputDPI / Constants.DriverNormalizedDPI, Calculator.SimulatedInputCombined);
         }
     }
 }

--- a/grapher/Models/Calculations/Data/AccelDataCombined.cs
+++ b/grapher/Models/Calculations/Data/AccelDataCombined.cs
@@ -43,7 +43,7 @@ namespace grapher.Models.Calculations.Data
         public void CreateGraphData(ManagedAccel accel, Profile settings)
         {
             Clear();
-            Calculator.Calculate(X, accel, settings.sensitivity, Calculator.SimulatedInputCombined);
+            Calculator.Calculate(X, accel, settings.outputDPI / 1000.0, Calculator.SimulatedInputCombined);
         }
     }
 }

--- a/grapher/Models/Calculations/Data/AccelDataXYComponential.cs
+++ b/grapher/Models/Calculations/Data/AccelDataXYComponential.cs
@@ -1,4 +1,5 @@
-﻿using grapher.Models.Charts;
+﻿using grapher.Common;
+using grapher.Models.Charts;
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/grapher/Models/Calculations/Data/AccelDataXYComponential.cs
+++ b/grapher/Models/Calculations/Data/AccelDataXYComponential.cs
@@ -57,8 +57,8 @@ namespace grapher.Models.Calculations.Data
         public void CreateGraphData(ManagedAccel accel, Profile settings)
         {
             Clear();
-            var sensY = settings.sensitivity * settings.yxSensRatio;
-            Calculator.Calculate(X, accel, settings.sensitivity, Calculator.SimulatedInputX);
+            var sensY = settings.outputDPI * settings.yxSensRatio / 1000.0;
+            Calculator.Calculate(X, accel, settings.outputDPI / 1000.0, Calculator.SimulatedInputX);
             Calculator.Calculate(Y, accel, sensY, Calculator.SimulatedInputY);
         }
     }

--- a/grapher/Models/Calculations/Data/AccelDataXYComponential.cs
+++ b/grapher/Models/Calculations/Data/AccelDataXYComponential.cs
@@ -59,7 +59,7 @@ namespace grapher.Models.Calculations.Data
         {
             Clear();
             var sensFactor = Helper.GetSensitivityFactor(settings);
-            var sensY = sensFactor * settings.yxSensRatio;
+            var sensY = sensFactor * settings.yxOutputDPIRatio;
             Calculator.Calculate(X, accel, sensFactor, Calculator.SimulatedInputX);
             Calculator.Calculate(Y, accel, sensY, Calculator.SimulatedInputY);
         }

--- a/grapher/Models/Calculations/Data/AccelDataXYComponential.cs
+++ b/grapher/Models/Calculations/Data/AccelDataXYComponential.cs
@@ -57,8 +57,8 @@ namespace grapher.Models.Calculations.Data
         public void CreateGraphData(ManagedAccel accel, Profile settings)
         {
             Clear();
-            var sensY = settings.outputDPI * settings.yxSensRatio / 1000.0;
-            Calculator.Calculate(X, accel, settings.outputDPI / 1000.0, Calculator.SimulatedInputX);
+            var sensY = settings.outputDPI * settings.yxSensRatio / Constants.DriverNormalizedDPI;
+            Calculator.Calculate(X, accel, settings.outputDPI / Constants.DriverNormalizedDPI, Calculator.SimulatedInputX);
             Calculator.Calculate(Y, accel, sensY, Calculator.SimulatedInputY);
         }
     }

--- a/grapher/Models/Calculations/Data/AccelDataXYComponential.cs
+++ b/grapher/Models/Calculations/Data/AccelDataXYComponential.cs
@@ -58,8 +58,9 @@ namespace grapher.Models.Calculations.Data
         public void CreateGraphData(ManagedAccel accel, Profile settings)
         {
             Clear();
-            var sensY = settings.outputDPI * settings.yxSensRatio / Constants.DriverNormalizedDPI;
-            Calculator.Calculate(X, accel, settings.outputDPI / Constants.DriverNormalizedDPI, Calculator.SimulatedInputX);
+            var sensFactor = Helper.GetSensitivityFactor(settings);
+            var sensY = sensFactor * settings.yxSensRatio;
+            Calculator.Calculate(X, accel, sensFactor, Calculator.SimulatedInputX);
             Calculator.Calculate(Y, accel, sensY, Calculator.SimulatedInputY);
         }
     }

--- a/grapher/Models/Calculations/Data/AccelDataXYDirectional.cs
+++ b/grapher/Models/Calculations/Data/AccelDataXYDirectional.cs
@@ -1,4 +1,5 @@
-﻿using grapher.Models.Charts;
+﻿using grapher.Common;
+using grapher.Models.Charts;
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/grapher/Models/Charts/AccelCharts.cs
+++ b/grapher/Models/Charts/AccelCharts.cs
@@ -1,4 +1,5 @@
-﻿using grapher.Models.Calculations;
+﻿using grapher.Common;
+using grapher.Models.Calculations;
 using grapher.Models.Calculations.Data;
 using grapher.Models.Charts;
 using grapher.Models.Charts.ChartState;

--- a/grapher/Models/Charts/ChartState/ChartState.cs
+++ b/grapher/Models/Charts/ChartState/ChartState.cs
@@ -1,4 +1,5 @@
-﻿using grapher.Models.Calculations;
+﻿using grapher.Common;
+using grapher.Models.Calculations;
 using grapher.Models.Calculations.Data;
 using System;
 using System.Windows.Forms;

--- a/grapher/Models/Charts/ChartState/ChartStateManager.cs
+++ b/grapher/Models/Charts/ChartState/ChartStateManager.cs
@@ -1,4 +1,5 @@
-﻿using grapher.Models.Calculations;
+﻿using grapher.Common;
+using grapher.Models.Calculations;
 using System.Windows.Forms;
 
 namespace grapher.Models.Charts.ChartState

--- a/grapher/Models/Charts/ChartState/ChartStateManager.cs
+++ b/grapher/Models/Charts/ChartState/ChartStateManager.cs
@@ -56,7 +56,7 @@ namespace grapher.Models.Charts.ChartState
 
             if (settings.inputSpeedArgs.combineMagnitudes)
             {
-                if (settings.yxSensRatio != 1 ||
+                if (settings.yxOutputDPIRatio != 1 ||
                     settings.domainXY.x != settings.domainXY.y ||
                     settings.rangeXY.x != settings.rangeXY.y)
                 {

--- a/grapher/Models/Charts/ChartXY.cs
+++ b/grapher/Models/Charts/ChartXY.cs
@@ -1,4 +1,5 @@
-﻿using grapher.Models.Mouse;
+﻿using grapher.Common;
+using grapher.Models.Mouse;
 using System;
 using System.Collections;
 using System.Windows.Forms.DataVisualization.Charting;

--- a/grapher/Models/Fields/Field.cs
+++ b/grapher/Models/Fields/Field.cs
@@ -2,6 +2,7 @@
 using System.Drawing;
 using System.Globalization;
 using System.Windows.Forms;
+using grapher.Common;
 using grapher.Models.Theming;
 
 namespace grapher

--- a/grapher/Models/Fields/FieldXY.cs
+++ b/grapher/Models/Fields/FieldXY.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using grapher.Common;
+using System;
 using System.Windows.Forms;
 
 namespace grapher

--- a/grapher/Models/Mouse/MouseWatcher.cs
+++ b/grapher/Models/Mouse/MouseWatcher.cs
@@ -1,4 +1,5 @@
-﻿using grapher.Models.Serialized;
+﻿using grapher.Common;
+using grapher.Models.Serialized;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;

--- a/grapher/Models/Mouse/MouseWatcher.cs
+++ b/grapher/Models/Mouse/MouseWatcher.cs
@@ -785,8 +785,8 @@ namespace grapher.Models.Mouse
 
                 Vec2<double> dirMults = new Vec2<double>
                 {
-                    x = SettingsManager.ActiveProfile.lrSensRatio,
-                    y = SettingsManager.ActiveProfile.udSensRatio
+                    x = SettingsManager.ActiveProfile.lrOutputDPIRatio,
+                    y = SettingsManager.ActiveProfile.udOutputDPIRatio
                 };
 
                 if (dirMults.x > 0 && x < 0)

--- a/grapher/Models/Options/AccelOptionSet.cs
+++ b/grapher/Models/Options/AccelOptionSet.cs
@@ -1,4 +1,5 @@
-﻿using grapher.Models.Serialized;
+﻿using grapher.Common;
+using grapher.Models.Serialized;
 using System.Drawing;
 using System.Windows.Forms;
 

--- a/grapher/Models/Options/AccelTypeOptions.cs
+++ b/grapher/Models/Options/AccelTypeOptions.cs
@@ -1,4 +1,5 @@
-﻿using grapher.Layouts;
+﻿using grapher.Common;
+using grapher.Layouts;
 using grapher.Models.Options;
 using grapher.Models.Options.Cap;
 using grapher.Models.Options.LUT;

--- a/grapher/Models/Options/ActiveValueLabel.cs
+++ b/grapher/Models/Options/ActiveValueLabel.cs
@@ -1,5 +1,6 @@
 ﻿using System.Drawing;
 using System.Windows.Forms;
+using grapher.Common;
 using grapher.Models.Theming;
 
 namespace grapher.Models.Options

--- a/grapher/Models/Options/ActiveValueLabelXY.cs
+++ b/grapher/Models/Options/ActiveValueLabelXY.cs
@@ -1,4 +1,5 @@
-﻿using System.Drawing;
+﻿using grapher.Common;
+using System.Drawing;
 
 namespace grapher.Models.Options
 {

--- a/grapher/Models/Options/ApplyOptions.cs
+++ b/grapher/Models/Options/ApplyOptions.cs
@@ -102,7 +102,7 @@ namespace grapher.Models.Options
 
         public void SetActiveValues(Profile settings)
         {
-            Sensitivity.SetActiveValue(settings.outputDPI / Constants.DriverNormalizedDPI);
+            Sensitivity.SetActiveValue(Helper.GetSensitivityFactor(settings));
             YToXRatio.SetActiveValue(settings.yxSensRatio);
             Rotation.SetActiveValue(settings.rotation);
             

--- a/grapher/Models/Options/ApplyOptions.cs
+++ b/grapher/Models/Options/ApplyOptions.cs
@@ -102,7 +102,7 @@ namespace grapher.Models.Options
 
         public void SetActiveValues(Profile settings)
         {
-            Sensitivity.SetActiveValue(settings.sensitivity);
+            Sensitivity.SetActiveValue(settings.outputDPI / 1000.0);
             YToXRatio.SetActiveValue(settings.yxSensRatio);
             Rotation.SetActiveValue(settings.rotation);
             

--- a/grapher/Models/Options/ApplyOptions.cs
+++ b/grapher/Models/Options/ApplyOptions.cs
@@ -103,7 +103,7 @@ namespace grapher.Models.Options
         public void SetActiveValues(Profile settings)
         {
             Sensitivity.SetActiveValue(Helper.GetSensitivityFactor(settings));
-            YToXRatio.SetActiveValue(settings.yxSensRatio);
+            YToXRatio.SetActiveValue(settings.yxOutputDPIRatio);
             Rotation.SetActiveValue(settings.rotation);
             
             WholeVectorCheckBox.Checked = settings.inputSpeedArgs.combineMagnitudes;

--- a/grapher/Models/Options/ApplyOptions.cs
+++ b/grapher/Models/Options/ApplyOptions.cs
@@ -1,5 +1,5 @@
-﻿using grapher.Models.Options.Directionality;
-using grapher.Models.Serialized;
+﻿using grapher.Common;
+using grapher.Models.Options.Directionality;
 using System;
 using System.Drawing;
 using System.Windows.Forms;

--- a/grapher/Models/Options/ApplyOptions.cs
+++ b/grapher/Models/Options/ApplyOptions.cs
@@ -102,7 +102,7 @@ namespace grapher.Models.Options
 
         public void SetActiveValues(Profile settings)
         {
-            Sensitivity.SetActiveValue(settings.outputDPI / 1000.0);
+            Sensitivity.SetActiveValue(settings.outputDPI / Constants.DriverNormalizedDPI);
             YToXRatio.SetActiveValue(settings.yxSensRatio);
             Rotation.SetActiveValue(settings.rotation);
             

--- a/grapher/Models/Options/Cap/CapTypeOptions.cs
+++ b/grapher/Models/Options/Cap/CapTypeOptions.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using System.Windows.Forms;
+using grapher.Common;
 using grapher.Models.Theming;
 
 namespace grapher.Models.Options.Cap

--- a/grapher/Models/Options/ComboBoxOptionsBase.cs
+++ b/grapher/Models/Options/ComboBoxOptionsBase.cs
@@ -1,4 +1,5 @@
-﻿using System.Windows.Forms;
+﻿using grapher.Common;
+using System.Windows.Forms;
 
 namespace grapher.Models.Options
 {

--- a/grapher/Models/Options/Directionality/DirectionalityOptions.cs
+++ b/grapher/Models/Options/Directionality/DirectionalityOptions.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using System.Windows.Forms;
+using grapher.Common;
 using grapher.Models.Theming;
 
 namespace grapher.Models.Options.Directionality

--- a/grapher/Models/Options/Option.cs
+++ b/grapher/Models/Options/Option.cs
@@ -1,6 +1,7 @@
 ﻿using grapher.Models.Options;
 using System.Windows.Forms;
 using grapher.Models.Theming.Controls;
+using grapher.Common;
 
 namespace grapher
 {

--- a/grapher/Models/Options/OptionBase.cs
+++ b/grapher/Models/Options/OptionBase.cs
@@ -1,4 +1,6 @@
-﻿namespace grapher.Models.Options
+﻿using grapher.Common;
+
+namespace grapher.Models.Options
 {
     public abstract class OptionBase : IOption
     {

--- a/grapher/Models/Options/SwitchOption.cs
+++ b/grapher/Models/Options/SwitchOption.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using grapher.Common;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;

--- a/grapher/Models/Serialized/GUISettings.cs
+++ b/grapher/Models/Serialized/GUISettings.cs
@@ -1,4 +1,5 @@
-﻿using Newtonsoft.Json;
+﻿using grapher.Common;
+using Newtonsoft.Json;
 using System;
 using System.ComponentModel;
 using System.IO;

--- a/grapher/Models/Serialized/SettingsManager.cs
+++ b/grapher/Models/Serialized/SettingsManager.cs
@@ -10,6 +10,7 @@ using System.Collections.Generic;
 using System.Dynamic;
 using System.Linq;
 using grapher.Models.Theming;
+using grapher.Common;
 
 namespace grapher.Models.Serialized
 {

--- a/grapher/Models/Serialized/SettingsManager.cs
+++ b/grapher/Models/Serialized/SettingsManager.cs
@@ -201,8 +201,8 @@ namespace grapher.Models.Serialized
             settings.snap = UserProfile.snap;
             settings.maximumSpeed = UserProfile.maximumSpeed;
             settings.minimumSpeed = UserProfile.minimumSpeed;
-            settings.lrSensRatio = UserProfile.lrSensRatio;
-            settings.udSensRatio = UserProfile.udSensRatio;
+            settings.lrOutputDPIRatio = UserProfile.lrOutputDPIRatio;
+            settings.udOutputDPIRatio = UserProfile.udOutputDPIRatio;
         }
 
         public GUISettings MakeGUISettingsFromFields()

--- a/grapher/grapher.csproj
+++ b/grapher/grapher.csproj
@@ -77,7 +77,7 @@
     <Compile Include="AboutBox.Designer.cs">
       <DependentUpon>AboutBox.cs</DependentUpon>
     </Compile>
-    <Compile Include="Constants\Constants.cs" />
+    <Compile Include="Common\Constants.cs" />
     <Compile Include="DeviceMenuForm.cs">
       <SubType>Form</SubType>
     </Compile>

--- a/grapher/grapher.csproj
+++ b/grapher/grapher.csproj
@@ -78,6 +78,7 @@
       <DependentUpon>AboutBox.cs</DependentUpon>
     </Compile>
     <Compile Include="Common\Constants.cs" />
+	<Compile Include="Common\Helper.cs" />
     <Compile Include="DeviceMenuForm.cs">
       <SubType>Form</SubType>
     </Compile>

--- a/wrapper-tests/EndToEndTests.cs
+++ b/wrapper-tests/EndToEndTests.cs
@@ -15,5 +15,16 @@ namespace wrapper_tests
             Assert.AreEqual(input.x, output.Item1);
             Assert.AreEqual(input.y, output.Item2);
         }
+
+        [TestMethod]
+        public void ModifyInput_WithOutputDPI_HasCorrectFactor()
+        {
+            var accel = new ManagedAccel();
+            (int x, int y) input = (1, 1);
+            var output = accel.Accelerate(input.x, input.y, 1, 1);
+
+            Assert.AreEqual(input.x, output.Item1);
+            Assert.AreEqual(input.y, output.Item2);
+        }
     }
 }

--- a/wrapper-tests/EndToEndTests.cs
+++ b/wrapper-tests/EndToEndTests.cs
@@ -19,12 +19,19 @@ namespace wrapper_tests
         [TestMethod]
         public void ModifyInput_WithOutputDPI_HasCorrectFactor()
         {
-            var accel = new ManagedAccel();
+            double expectedFactor = 2;
+            double expectedNormalizedDPI = 1000;
             (int x, int y) input = (1, 1);
+
+            var profile = new Profile();
+            profile.outputDPI = expectedFactor * expectedNormalizedDPI;
+            var accel = new ManagedAccel(profile);
+
             var output = accel.Accelerate(input.x, input.y, 1, 1);
 
-            Assert.AreEqual(input.x, output.Item1);
-            Assert.AreEqual(input.y, output.Item2);
+            (double x, double y) expectedOutput = (expectedFactor * input.x, expectedFactor * input.y);
+            Assert.AreEqual(expectedOutput.x, output.Item1);
+            Assert.AreEqual(expectedOutput.y, output.Item2);
         }
     }
 }

--- a/wrapper/wrapper.cpp
+++ b/wrapper/wrapper.cpp
@@ -138,12 +138,12 @@ public ref struct Profile
 
     [JsonProperty("Output DPI")]
     double outputDPI;
-    [JsonProperty("Y/X sensitivity ratio (vertical sens multiplier)")]
-    double yxSensRatio;
-    [JsonProperty("L/R sensitivity ratio (left sens multiplier)")]
-    double lrSensRatio;
-    [JsonProperty("U/D sensitivity ratio (up sens multiplier)")]
-    double udSensRatio;
+    [JsonProperty("Y/X output DPI ratio (vertical sens multiplier)")]
+    double yxOutputDPIRatio;
+    [JsonProperty("L/R output DPI ratio (left sens multiplier)")]
+    double lrOutputDPIRatio;
+    [JsonProperty("U/D output DPI ratio (up sens multiplier)")]
+    double udOutputDPIRatio;
 
     [JsonProperty("Degrees of rotation")]
     double rotation;
@@ -179,7 +179,7 @@ public value struct DeviceConfig {
     [JsonProperty("Use constant time interval based on polling rate", Required = Required::Default)]
     bool pollTimeLock;
 
-    [JsonProperty("DPI (normalizes sens to 1000dpi and converts input speed unit: counts/ms -> in/s)")]
+    [JsonProperty("DPI (normalizes input speed unit: counts/ms -> in/s)")]
     int dpi;
 
     [JsonProperty("Polling rate Hz (keep at 0 for automatic adjustment)")]

--- a/wrapper/wrapper.cpp
+++ b/wrapper/wrapper.cpp
@@ -136,8 +136,8 @@ public ref struct Profile
     [JsonProperty("Input speed calculation parameters")]
     SpeedArgs inputSpeedArgs;
 
-    [JsonProperty("Sensitivity multiplier")]
-    double sensitivity;
+    [JsonProperty("Output DPI")]
+    double outputDPI;
     [JsonProperty("Y/X sensitivity ratio (vertical sens multiplier)")]
     double yxSensRatio;
     [JsonProperty("L/R sensitivity ratio (left sens multiplier)")]


### PR DESCRIPTION
Future releases of Raw Accel are targeting having users set output DPI directly via the device and profiles features, as opposed to the current method of setting a multiplier on all incoming mouse counts. This change switches profiles to take an "output DPI" instead of a "sensitivity multiplier".
The term "sensitivity" is used to describe ratio of input/output, but it is not always clear which input and output are being affected. Users confuse the use of "sensitivity multiplier" in Raw Accel with the sensitivity parameters in games or in Windows settings, despite the "multiplier" term.  
This change isolates almost all uses of the term "sensitivity" to the GUI layer, which is planned to be replaced. Remaining mentions of "sens" in JSON descriptors are left to help users understand that for the settings in question, the name has changed but not the functionality.
Guide will be updated to reflect this in future change.