### PR TITLE
Add Autostart and Per-User Settings

### DIFF
--- a/autorun.ps1
+++ b/autorun.ps1
@@ -1,0 +1,16 @@
+param (
+    [ValidateNotNullOrEmpty()][string]$SettingsFile = "$(Join-Path $Env:LOCALAPPDATA (Join-Path 'Raw Accel' 'settings.json'))"
+)
+
+$SettingsFile = Convert-Path($SettingsFile)
+$settingsDirectory = [IO.Path]::GetDirectoryName($SettingsFile)
+$settingsFileName = [IO.Path]::GetFileName($SettingsFile)
+
+$rawaccel_exe = Join-Path $PSScriptRoot rawaccel.exe
+$writer_exe = Join-Path $PSScriptRoot writer.exe
+
+if (Test-Path -PathType 'Container' -Path $settingsDirectory) {
+    Start-Process -WorkingDirectory $settingsDirectory -FilePath $writer_exe -ArgumentList $settingsFileName
+} elseif (New-Item -ItemType 'directory' -Path $settingsDirectory -Force) {
+    Start-Process -WorkingDirectory $settingsDirectory -FilePath $rawaccel_exe
+}

--- a/doc/Guide.md
+++ b/doc/Guide.md
@@ -13,7 +13,7 @@ We recommend copying the release directory into `%PROGRAMFILES%\Raw Accel`.
 
 - Run `installer.exe` in the release directory to install the Raw Accel driver. Restart your computer for the installation to take effect.
 
-- Run `install-autorun.ps1` in the release directory to enable user specific settings on sign in for each user. The settings are stored in `%LOCALAPPDATA%\Raw Accel`
+- Run `install-autorun.ps1` in the release directory to enable user specific settings on sign in for each user. The settings are stored in `%LOCALAPPDATA%\Raw Accel`.
 
 - Run `install-shortcut.ps1` in the release directory to add a user specific shortcut to the Raw Accel GUI. The settings are stored in `%LOCALAPPDATA%\Raw Accel`. Sign out and back in for the installation to take effect.
 

--- a/doc/Guide.md
+++ b/doc/Guide.md
@@ -9,7 +9,13 @@ Visit the [Releases page](https://github.com/a1xd/rawaccel/releases) and navigat
   * Visual C++ 2019 runtime, [download here](https://aka.ms/vs/16/release/vc_redist.x64.exe)
   * .NET Framework 4.7.2+ runtime, [download here](https://dotnet.microsoft.com/download/dotnet-framework/net48)
 
+We recommend copying the release directory into `%PROGRAMFILES%\Raw Accel`.
+
 - Run `installer.exe` in the release directory to install the Raw Accel driver. Restart your computer for the installation to take effect.
+
+- Run `install-autorun.ps1` in the release directory to enable user specific settings on sign in for each user. The settings are stored in `%LOCALAPPDATA%\Raw Accel`
+
+- Run `uninstall-autorun.ps1` in the release directory to disable user specific settings.
 
 - Run `uninstaller.exe` in the release directory to uninstall the driver. Restart for the uninstallation to take effect.
 

--- a/doc/Guide.md
+++ b/doc/Guide.md
@@ -15,11 +15,15 @@ We recommend copying the release directory into `%PROGRAMFILES%\Raw Accel`.
 
 - Run `install-autorun.ps1` in the release directory to enable user specific settings on sign in for each user. The settings are stored in `%LOCALAPPDATA%\Raw Accel`
 
+- Run `install-shortcut.ps1` in the release directory to add a user specific shortcut to the Raw Accel GUI. The settings are stored in `%LOCALAPPDATA%\Raw Accel`. Sign out and back in for the installation to take effect.
+
+- Run `rawaccel.exe` when the driver is installed in order to run the Raw Accel GUI.
+
+## Uninstallation
+
 - Run `uninstall-autorun.ps1` in the release directory to disable user specific settings.
 
 - Run `uninstaller.exe` in the release directory to uninstall the driver. Restart for the uninstallation to take effect.
-
-- Run `rawaccel.exe` when the driver is installed in order to run the Raw Accel GUI.
 
 ## Philosophy
 The Raw Accel driver and GUI's workings and exposed parameters are based on our understanding of mouse acceleration. Our understanding includes the concepts of "[gain](#gain-switch)", "[whole vs by component](#horizontal-and-vertical)", and "[anisotropy](#anisotropy)." For clarity, we will outline this understanding here. Those uninterested can skip to [Features](#features) below.

--- a/doc/Guide.md
+++ b/doc/Guide.md
@@ -9,7 +9,7 @@ Visit the [Releases page](https://github.com/a1xd/rawaccel/releases) and navigat
   * Visual C++ 2019 runtime, [download here](https://aka.ms/vs/16/release/vc_redist.x64.exe)
   * .NET Framework 4.7.2+ runtime, [download here](https://dotnet.microsoft.com/download/dotnet-framework/net48)
 
-We recommend copying the release directory into `%PROGRAMFILES%\Raw Accel`.
+We recommend extracting the release directory into `%PROGRAMFILES%\Raw Accel`.
 
 - Run `installer.exe` in the release directory to install the Raw Accel driver. Restart your computer for the installation to take effect.
 

--- a/install-autorun.ps1
+++ b/install-autorun.ps1
@@ -4,7 +4,7 @@ if (-Not ([Security.Principal.WindowsPrincipal] [Security.Principal.WindowsIdent
     Exit
 }
 
-$unlockScript = Join-Path $PSScriptRoot autorun.ps1
+$autorunScript = Join-Path $PSScriptRoot autorun.ps1
 $stateChangeTrigger = Get-CimClass `
     -Namespace ROOT\Microsoft\Windows\TaskScheduler `
     -ClassName MSFT_TaskSessionStateChangeTrigger
@@ -23,5 +23,5 @@ Register-ScheduledTask `
                 } `
                 -ClientOnly
         ) `
-    -Action (New-ScheduledTaskAction -Execute 'PowerShell' -Argument ('-WindowStyle Hidden -File "{0}"' -f $unlockScript)) `
+    -Action (New-ScheduledTaskAction -Execute 'PowerShell' -Argument ('-WindowStyle Hidden -File "{0}"' -f $autorunScript)) `
     -Settings (New-ScheduledTaskSettingsSet -AllowStartIfOnBatteries -ExecutionTimeLimit 0)

--- a/install-autorun.ps1
+++ b/install-autorun.ps1
@@ -1,0 +1,27 @@
+# Run as administrator
+if (-Not ([Security.Principal.WindowsPrincipal] [Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole([Security.Principal.WindowsBuiltInRole] 'Administrator')) {
+    Start-Process -WorkingDirectory $PWD -FilePath PowerShell.exe -Verb Runas -ArgumentList $(('-File "{0}"' -f $MyInvocation.MyCommand.Path); $MyInvocation.UnboundArguments)
+    Exit
+}
+
+$unlockScript = Join-Path $PSScriptRoot autorun.ps1
+$stateChangeTrigger = Get-CimClass `
+    -Namespace ROOT\Microsoft\Windows\TaskScheduler `
+    -ClassName MSFT_TaskSessionStateChangeTrigger
+
+Register-ScheduledTask `
+    -Force `
+    -TaskName 'Autorun on sign in' `
+    -TaskPath '\Raw Accel\' `
+    -Description 'Apply user specific Raw Accel settings at sign in for each user.' `
+    -Principal (New-ScheduledTaskPrincipal -GroupId Users) `
+    -Trigger (New-ScheduledTaskTrigger -AtLogOn), `
+        (
+            New-CimInstance $stateChangeTrigger `
+                -Property @{
+                    StateChange = 8  # TASK_SESSION_STATE_CHANGE_TYPE.TASK_SESSION_UNLOCK (taskschd.h)
+                } `
+                -ClientOnly
+        ) `
+    -Action (New-ScheduledTaskAction -Execute 'PowerShell' -Argument ('-WindowStyle Hidden -File "{0}"' -f $unlockScript)) `
+    -Settings (New-ScheduledTaskSettingsSet -AllowStartIfOnBatteries -ExecutionTimeLimit 0)

--- a/install-shortcut.ps1
+++ b/install-shortcut.ps1
@@ -1,0 +1,13 @@
+# Run as administrator
+if (-Not ([Security.Principal.WindowsPrincipal] [Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole([Security.Principal.WindowsBuiltInRole] 'Administrator')) {
+    Start-Process -WorkingDirectory $PWD -FilePath PowerShell.exe -Verb Runas -ArgumentList $(('-File "{0}"' -f $MyInvocation.MyCommand.Path); $MyInvocation.UnboundArguments)
+    Exit
+}
+
+$rawaccel_exe = Join-Path $PSScriptRoot rawaccel.exe
+
+$shell = New-Object -comObject WScript.Shell
+$shortcut = $shell.CreateShortcut('C:\ProgramData\Microsoft\Windows\Start Menu\Programs\Raw Accel.lnk')
+$shortcut.TargetPath = $rawaccel_exe
+$Shortcut.WorkingDirectory = '%LOCALAPPDATA%\Raw Accel'
+$shortcut.Save()

--- a/install-shortcut.ps1
+++ b/install-shortcut.ps1
@@ -7,7 +7,8 @@ if (-Not ([Security.Principal.WindowsPrincipal] [Security.Principal.WindowsIdent
 $rawaccel_exe = Join-Path $PSScriptRoot rawaccel.exe
 
 $shell = New-Object -comObject WScript.Shell
-$shortcut = $shell.CreateShortcut('C:\ProgramData\Microsoft\Windows\Start Menu\Programs\Raw Accel.lnk')
+$shortcut = $shell.CreateShortcut("$Env:PROGRAMDATA\Microsoft\Windows\Start Menu\Programs\Raw Accel.lnk")
 $shortcut.TargetPath = $rawaccel_exe
 $Shortcut.WorkingDirectory = '%LOCALAPPDATA%\Raw Accel'
+$Shortcut.Description = 'Edit mouse acceleration curves'
 $shortcut.Save()

--- a/uninstall-autorun.ps1
+++ b/uninstall-autorun.ps1
@@ -1,0 +1,10 @@
+# Run as administrator
+if (-Not ([Security.Principal.WindowsPrincipal] [Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole([Security.Principal.WindowsBuiltInRole] 'Administrator')) {
+    Start-Process -WorkingDirectory $PWD -FilePath PowerShell.exe -Verb Runas -ArgumentList $(('-File "{0}"' -f $MyInvocation.MyCommand.Path); $MyInvocation.UnboundArguments)
+    Exit
+}
+
+Unregister-ScheduledTask `
+    -TaskName 'Autorun on sign in' `
+    -TaskPath '\Raw Accel\' `
+    -Confirm:$false


### PR DESCRIPTION
This change adds scripts to enable per-user Raw Accel settings.

There are three primary parts to this change:
1. A Start Menu shortcut installer script.
2. A Task Scheduler task installer/uninstaller to run the autorun script at sign in.
3. Additional guide instructions to enable this feature.

Since Raw Accel applies globally, users sharing a computer needed to manually manage different settings files if they wanted to have different Raw Accel settings. This change solves that issue by setting the working directory of `writer.exe` and `rawaccel.exe` to a user dynamic path with `%LOCALAPPDATA%`, and automatically applying those user specific settings on sign in.

Result of running `install-shortcut.ps1`:
![shortcut](https://github.com/user-attachments/assets/ab2466bf-6a3f-405c-a255-3deb38212250)

Result of running `install-autorun.ps1`:
![task](https://github.com/user-attachments/assets/91875829-450f-44d5-b749-9e9140469d9b)

This change resolves #113 and is related to #223 #168 #154 #152 #130 #95 #83 #75 #55 #43

----

### Notes:

1. Settings are stored under `%LOCALAPPDATA%\Raw Accel` for each user.
2. If settings don't already exist, we run `rawaccel.exe` in `%LOCALAPPDATA%\Raw Accel` to initialize them.
3. Admin privileges are required to add a global task and to write to `%PROGRAMDATA%\Microsoft\Windows\Start Menu\Programs`.