### PR TITLE
Add GUI toggle for startup shortcut and set working directory

### DIFF
--- a/grapher/Form1.Designer.cs
+++ b/grapher/Form1.Designer.cs
@@ -206,6 +206,7 @@ namespace grapher
             this.showVelocityGainToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.showLastMouseMoveToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.advancedToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.AutoLoadStartupItem = new System.Windows.Forms.ToolStripMenuItem();
             this.AutoWriteMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.DeviceMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.chartsPanel = new System.Windows.Forms.Panel();
@@ -1689,15 +1690,16 @@ namespace grapher
             // advancedToolStripMenuItem
             // 
             this.advancedToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.AutoLoadStartupItem,
             this.AutoWriteMenuItem,
-            this.DeviceMenuItem});
+            this.DeviceMenuItem}); 
             this.advancedToolStripMenuItem.Name = "advancedToolStripMenuItem";
             this.advancedToolStripMenuItem.Size = new System.Drawing.Size(72, 20);
             this.advancedToolStripMenuItem.Text = "Advanced";
             // 
             // AutoWriteMenuItem
             // 
-            this.AutoWriteMenuItem.Checked = true;
+            this.AutoWriteMenuItem.Checked = false;
             this.AutoWriteMenuItem.CheckOnClick = true;
             this.AutoWriteMenuItem.CheckState = System.Windows.Forms.CheckState.Checked;
             this.AutoWriteMenuItem.Name = "AutoWriteMenuItem";
@@ -1709,6 +1711,19 @@ namespace grapher
             this.DeviceMenuItem.Name = "DeviceMenuItem";
             this.DeviceMenuItem.Size = new System.Drawing.Size(257, 22);
             this.DeviceMenuItem.Text = "Device Menu";
+            //
+            // AutoLoadStartupItem
+            //
+            this.AutoLoadStartupItem.Checked = false;
+            this.AutoLoadStartupItem.CheckOnClick = true;
+            this.AutoLoadStartupItem.CheckState = System.Windows.Forms.CheckState.Checked;
+            this.AutoLoadStartupItem.Name = "AutoLoadStartupItem";
+            this.AutoLoadStartupItem.Size = new System.Drawing.Size(257, 22);
+            this.AutoLoadStartupItem.Text = "Load GUI On Windows Startup";
+      
+
+
+
             // 
             // chartsPanel
             // 
@@ -2492,6 +2507,7 @@ namespace grapher
         private System.Windows.Forms.DataVisualization.Charting.Chart VelocityChart;
         private System.Windows.Forms.DataVisualization.Charting.Chart AccelerationChart;
         private System.Windows.Forms.ToolStripMenuItem AutoWriteMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem AutoLoadStartupItem;
         private System.Windows.Forms.Panel DirectionalityPanel;
         private System.Windows.Forms.Label DirectionalityRangeLabel;
         private System.Windows.Forms.Label DirectionalDomainLabel;

--- a/grapher/Form1.cs
+++ b/grapher/Form1.cs
@@ -22,6 +22,7 @@ namespace grapher
         {
             InitializeComponent();
 
+
             Version driverVersion = VersionHelper.ValidOrThrow();
 
             ToolStripMenuItem HelpMenuItem = new ToolStripMenuItem("&Help");
@@ -37,6 +38,17 @@ namespace grapher
                     })
             });
             
+            //
+            // load on startup addition
+            //
+            var startupFolder = Environment.GetFolderPath(Environment.SpecialFolder.Startup);
+            var shortcutPath = Path.Combine(startupFolder, "rawaccel.lnk");
+            AutoLoadStartupItem.Checked = File.Exists(shortcutPath);
+
+            AutoLoadStartupItem.Click += AutoLoadStartupItem_Click;
+
+
+
             var schemes = ColorSchemeManager.LoadSchemes().ToList();
             var themeMenuItem = new ToolStripMenuItem("&Themes");
 
@@ -89,6 +101,7 @@ namespace grapher
                 showLastMouseMoveToolStripMenuItem,
                 AutoWriteMenuItem,
                 DeviceMenuItem,
+                
                 ScaleMenuItem,
                 themeMenuItem,
                 DPITextBox,
@@ -364,6 +377,10 @@ namespace grapher
                 {
                     if (!gui) lnk.Arguments = Constants.DefaultSettingsFileName;
                     lnk.TargetPath = $@"{Application.StartupPath}\{name}.exe";
+                    
+                    // Set "start in" directory to the application path
+                    lnk.WorkingDirectory = Application.StartupPath;
+                    
                     lnk.Save();
                 }
                 finally
@@ -375,6 +392,17 @@ namespace grapher
             finally
             {
                 Marshal.FinalReleaseComObject(shell);
+            }
+        }
+
+        private void RemoveStartupShortcut()
+        {
+            var startupFolder = Environment.GetFolderPath(Environment.SpecialFolder.Startup);
+            var shortcutPath = Path.Combine(startupFolder, "rawaccel.lnk");
+
+            if (File.Exists(shortcutPath))
+            {
+                File.Delete(shortcutPath);
             }
         }
 
@@ -390,6 +418,27 @@ namespace grapher
         {
             Location = Properties.Settings.Default.Location;
             Size = Properties.Settings.Default.Size;
+        }
+        
+        private void AutoLoadStartupItem_Click(object sender, EventArgs e)
+        {
+            try
+            {
+                // Toggle shortcut creation/removal based on check box
+                if (AutoLoadStartupItem.Checked)
+                {
+                    MakeStartupShortcut(true);
+                }
+                else
+                {
+                    RemoveStartupShortcut();
+                }
+
+            }
+            catch (Exception ex)
+            {
+                MessageBox.Show($"Failed To Update Startup Shortcut: {ex.Message}","ERROR", MessageBoxButtons.OK, MessageBoxIcon.Error);
+            }
         }
     }
 }


### PR DESCRIPTION
1. Added a GUI button to enable/disable launching Raw Accel at Windows startup
2. Implemented logic to check and create/remove the shortcut in the startup folder
3. Fixed working directory to ensure the app runs correctly on startup
4. Tested manually by verifying shortcut creation, deletion, and launch behavior