### PR TITLE
Fix swhdju's issue

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -26,5 +26,5 @@ Raw Accel is not affiliated with any external websites, such as rawaccel.net or 
 simon - Driver & Acceleration Logic  
 \_m00se\_ - GUI, Gain features, Acceleration types  
 Sidiouth  - Primary tester and sounding board  
-TauntyArmordillo - Originator of the ideas behind Synchronous and Natural curve types
+TauntyArmordillo - Originator of the ideas behind Synchronous and Natural curve types\
 Kovaak - Brought us together

--- a/grapher/Models/Calculations/AccelCalculator.cs
+++ b/grapher/Models/Calculations/AccelCalculator.cs
@@ -85,7 +85,7 @@ namespace grapher.Models.Calculations
             return (int)Math.Round(angleTransformed);
         }
 
-        public void Calculate(AccelChartData data, ManagedAccel accel, double starter, ICollection<SimulatedMouseInput> simulatedInputData)
+        public void Calculate(AccelChartData data, ManagedAccel accel, double starter, ICollection<SimulatedMouseInput> simulatedInputData, Profile settings = null)
         {
             double lastInputMagnitude = 0;
             double lastOutputMagnitude = 0;
@@ -101,6 +101,9 @@ namespace grapher.Models.Calculations
             int index = 0;
             int logIndex = 0;
 
+            bool shouldStripRotation = settings != null && ShouldStripRot(settings);
+            (double rotX, double rotY) = shouldStripRotation ? GetRotVector(settings) : (1.0, 0.0);
+
             foreach (var simulatedInputDatum in simulatedInputData)
             {
                 if (simulatedInputDatum.velocity <= 0)
@@ -109,7 +112,16 @@ namespace grapher.Models.Calculations
                 }
 
                 var output = accel.Accelerate(simulatedInputDatum.x, simulatedInputDatum.y, 1, simulatedInputDatum.time);
-                var outMagnitude = DecimalCheck(Velocity(output.Item1, output.Item2, simulatedInputDatum.time));
+
+                double outputX = output.Item1;
+                double outputY = output.Item2;
+
+                if (shouldStripRotation)
+                {
+                    (outputX, outputY) = StripRot(outputX, outputY, rotX, rotY);
+                }
+
+                var outMagnitude = DecimalCheck(Velocity(outputX, outputY, simulatedInputDatum.time));
                 var inDiff = Math.Round(simulatedInputDatum.velocity - lastInputMagnitude, 5);
                 var outDiff = Math.Round(outMagnitude - lastOutputMagnitude, 5);
 

--- a/grapher/Models/Calculations/Data/AccelDataXYComponential.cs
+++ b/grapher/Models/Calculations/Data/AccelDataXYComponential.cs
@@ -60,8 +60,8 @@ namespace grapher.Models.Calculations.Data
             Clear();
             var sensFactor = Helper.GetSensitivityFactor(settings);
             var sensY = sensFactor * settings.yxOutputDPIRatio;
-            Calculator.Calculate(X, accel, sensFactor, Calculator.SimulatedInputX);
-            Calculator.Calculate(Y, accel, sensY, Calculator.SimulatedInputY);
+            Calculator.Calculate(X, accel, sensFactor, Calculator.SimulatedInputX, settings);
+            Calculator.Calculate(Y, accel, sensY, Calculator.SimulatedInputY, settings);
         }
     }
 }


### PR DESCRIPTION
#  Fix By Component Mode Rotation Stripping in Charts

Charting was not accounting for rotation when calculating by component curves.
Added detection for when rotation is present via ShouldStripRot(), then strips rotation from acceleration output before calculating chart magnitudes using StripRot().