### PR TITLE
Crash fix: Change settings directory to LocalApplicationData

### DIFF
--- a/doc/FAQ.md
+++ b/doc/FAQ.md
@@ -22,7 +22,7 @@ Instructions for these are in the beginning of the [guide](Guide.md#installation
 No. Once settings are passed to the driver by the GUI, they stay in use until the computer is shut down.
 
 ## Does the GUI need to be run every time I start my PC?
-Yes. The driver itself does not store your settings. To enable them on PC start, run the GUI, or run `writer.exe settings.json`.
+Yes. The driver itself does not store your settings. To enable them on PC start, run the GUI, or run `writer.exe %LOCALAPPDATA%\rawaccel\settings.json`.
 
 ## I don't understand something, or have some other question.
 Read the guide to see if it answers your question. If not, join our [Discord](https://discord.gg/7pQh8zH) and ask.

--- a/doc/Guide.md
+++ b/doc/Guide.md
@@ -174,7 +174,7 @@ Natural features a concave curve which starts at 1 and approaches some maximum s
 ![JumpExample](images/jump_example.png)
 
 ### Look Up Table
-This curve style is a blank canvas on which to create a curve. It allows the user to define the points which will make up the curve. For this reason, this mode is only for experts who know exactly what they want. Points can be supplied in the GUI according to format x1,y1;x2,y2;...xn.yn or in the settings.json in json format. The default Windows mouse acceleration settings (Enhanced Pointer Precision) can be very closely emulated with this style, using velocity points: "1.505035,0.85549892;4.375,3.30972978;13.51,15.17478447;140,354.7026875;".
+This curve style is a blank canvas on which to create a curve. It allows the user to define the points which will make up the curve. For this reason, this mode is only for experts who know exactly what they want. Points can be supplied in the GUI according to format x1,y1;x2,y2;...xn.yn or in the `%LOCALAPPDATA%\rawaccel\settings.json` file in json format. The default Windows mouse acceleration settings (Enhanced Pointer Precision) can be very closely emulated with this style, using velocity points: "1.505035,0.85549892;4.375,3.30972978;13.51,15.17478447;140,354.7026875;".
 ![LUTExample](images/LUT_example.png)
 
 ## Further Help

--- a/grapher/Common/Constants.cs
+++ b/grapher/Common/Constants.cs
@@ -123,11 +123,6 @@ namespace grapher.Common
         /// <summary> Text for y component. </summary>
         public const string YComponent = "Y";
 
-        /// <summary> Default name of settings file. </summary>
-        public const string DefaultSettingsFileName = @"settings.json";
-
-        public const string GuiConfigFileName = ".config";
-
         /// <summary> Text to directionality panel title when panel is closed. </summary>
         public const string DirectionalityTitleClosed = "Anisotropy \u25BC";
 

--- a/grapher/Common/Helper.cs
+++ b/grapher/Common/Helper.cs
@@ -1,7 +1,17 @@
-﻿namespace grapher.Common
+﻿using System;
+using System.IO;
+
+namespace grapher.Common
 {
     public static class Helper
     {
+        public static string GetCfgPath() => Path.Combine(
+            Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
+            "rawaccel");
+
+        public static string GetDefaultSettingsFilePath() => Path.Combine(
+            GetCfgPath(), @"settings.json");
+
         public static double GetSensitivityFactor(Profile profile) => GetSensitivityFactor(profile.outputDPI);
 
         public static double GetSensitivityFactor(double outputDPI) => outputDPI / Constants.DriverNormalizedDPI;

--- a/grapher/Form1.cs
+++ b/grapher/Form1.cs
@@ -361,7 +361,8 @@ namespace grapher
 
                 try
                 {
-                    if (!gui) lnk.Arguments = Constants.DefaultSettingsFileName;
+                    if (!gui) lnk.Arguments = Helper.GetDefaultSettingsFilePath();
+
                     lnk.TargetPath = $@"{Application.StartupPath}\{name}.exe";
                     lnk.Save();
                 }

--- a/grapher/Models/Serialized/GUISettings.cs
+++ b/grapher/Models/Serialized/GUISettings.cs
@@ -41,6 +41,13 @@ namespace grapher.Models.Serialized
         [DefaultValue("Light Theme")]
         public string CurrentColorScheme { get; set; }
 
+        [JsonIgnore]
+        public static string GuiConfigFileName {
+            get {
+                return Path.Combine(Helper.GetCfgPath(), ".config");
+            }
+        }
+
         #endregion Properties
 
         #region Methods
@@ -79,7 +86,7 @@ namespace grapher.Models.Serialized
 
         public void Save()
         {
-            File.WriteAllText(Constants.GuiConfigFileName, JsonConvert.SerializeObject(this));
+            File.WriteAllText(GuiConfigFileName, JsonConvert.SerializeObject(this));
         }
 
         public static GUISettings MaybeLoad()
@@ -89,7 +96,7 @@ namespace grapher.Models.Serialized
             try
             {
                 settings = JsonConvert.DeserializeObject<GUISettings>(
-                    File.ReadAllText(Constants.GuiConfigFileName));
+                    File.ReadAllText(GuiConfigFileName));
             }
             catch (Exception ex)
             {

--- a/grapher/Models/Serialized/SettingsManager.cs
+++ b/grapher/Models/Serialized/SettingsManager.cs
@@ -188,7 +188,7 @@ namespace grapher.Models.Serialized
 
                 UserConfig = settings;
                 ActiveConfig = settings;
-                File.WriteAllText(Constants.DefaultSettingsFileName, settings.ToJSON());
+                File.WriteAllText(Helper.GetDefaultSettingsFilePath(), settings.ToJSON());
 
                 new Thread(() => ActiveConfig.Activate()).Start();
             }
@@ -300,7 +300,7 @@ namespace grapher.Models.Serialized
 
         private DriverConfig InitActiveAndGetUserConfig()
         {
-            var path = Constants.DefaultSettingsFileName;
+            var path = Helper.GetDefaultSettingsFilePath();
             if (File.Exists(path))
             {
                 try

--- a/grapher/Models/Theming/IO/ThemeFileOperations.cs
+++ b/grapher/Models/Theming/IO/ThemeFileOperations.cs
@@ -1,4 +1,4 @@
-﻿using System;
+﻿using grapher.Common;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -13,7 +13,7 @@ namespace grapher.Models.Theming.IO
 
         public IEnumerable<ColorScheme> LoadThemes()
         {
-            ThemePath = Path.Combine(Environment.CurrentDirectory, "themes");
+            ThemePath = Path.Combine(Helper.GetCfgPath(), "themes");
 
             var pathFound = Directory.Exists(ThemePath);
 


### PR DESCRIPTION
Fix #284

This PR changes the rawaccel grapher app settings directory from `Environment.CurrentDirectory` (the CWD) to `Environment.SpecialFolder.LocalApplicationData` (the `%LOCALAPPDATA%\rawaccel`).

This fixes the problem where if the grapher GUI was launched from a CWD where the launching user didn't have write privileges, the app would crash. Most prominently, this would occur when attempting to launch the grapher app via the Windows key Start Menu or a Windows Explorer search result page ([repro steps here](https://github.com/RawAccelOfficial/rawaccel/issues/284#issuecomment-3126621712)), where CWD is set as `C:\WINDOWS\system32`, which typically A) would be write protected, and B) most likely is not where the user intended to store their rawaccel configs and themes.

An example crash stack trace of this bug is shown below:

```
System.UnauthorizedAccessException
  HResult=0x80070005
  Message=Access to the path 'C:\WINDOWS\system32\themes' is denied.
  Source=<Cannot evaluate the exception source>
  StackTrace:

		KERNELBASE.dll!00007ff9e0da804a()       Unknown
		[External Code]
>       mscorlib.dll!System.IO.__Error.WinIOError(int errorCode, string maybeFullPath) Line 139 C#
		mscorlib.dll!System.IO.Directory.InternalCreateDirectory(string fullPath, string path, object dirSecurityObj, bool checkHost) Line 263  C#
		mscorlib.dll!System.IO.Directory.InternalCreateDirectoryHelper(string path, bool checkHost) Line 93     C#
		rawaccel.exe!grapher.Models.Theming.IO.ThemeFileOperations.LoadThemes() Line 20 C#
		rawaccel.exe!grapher.RawAcceleration.RawAcceleration() Line 457 C#
		rawaccel.exe!grapher.Program.Main() Line 26     C#
		[External Code]
```

The unfortunate side-effect of this commit is "loss" of all existing user settings, unless the user manually moves them to the new location. But it's probably worth it, to fix the bug?