### PR TITLE
feat(tests): add continuity tests for Synchronous mode

### DIFF
--- a/wrapper-tests/SynchronousAccelTests.cs
+++ b/wrapper-tests/SynchronousAccelTests.cs
@@ -70,8 +70,85 @@ namespace wrapper_tests
                 Assert.AreEqual(expectedOutput, output.Item1, expectedOutput * 0.0001);
             }
         }
+        [TestMethod]
+        public void SynchronousAccel_ThresholdCrossing_IsContinuous()
+        {
+            double syncSpeed = 20;
+            double gamma = 0.5;
+            double motivity = 1.3;
 
-	}
+            // smooth = 0.03125 exactly results in sharpness = 16
+            double[] smoothValues = { 0.03126, 0.03125, 0.03124, 0.0 };
+
+            foreach (double smooth in smoothValues)
+            {
+                var profile = new Profile();
+                profile.outputDPI = 1000;
+                profile.argsX.mode = AccelMode.synchronous;
+                profile.argsX.gain = false;
+                profile.argsX.syncSpeed = syncSpeed;
+                profile.argsX.gamma = gamma;
+                profile.argsX.motivity = motivity;
+                profile.argsX.smooth = smooth;
+
+                var accel = new ManagedAccel(profile);
+                var pureSimulator = new UnclampedSynchronousSimulator(syncSpeed, motivity, gamma, smooth);
+
+                for (int input = 1; input < 100; input += 5)
+                {
+                    Tuple<double, double> output = accel.Accelerate(input, 0, 1, 10);
+
+                    double inputSpeed = (double)input / 10.0;
+                    double expectedOutput = (double)input * pureSimulator.Accelerate(inputSpeed);
+
+                    double delta = Math.Abs(output.Item1 - expectedOutput);
+                    double relativeError = delta / expectedOutput;
+
+                    Assert.IsTrue(relativeError < 0.001,
+                        $"Discontinuity found at smooth={smooth}, input={input}. " +
+                        $"Driver: {output.Item1}, Pure Math: {expectedOutput}, Error: {relativeError:P}");
+                }
+            }
+        }
+    }
+
+    /// <summary>
+    /// A simulator that follows the raw math WITHOUT the sharpness >= 16 optimization.
+    /// </summary>
+    public class UnclampedSynchronousSimulator
+    {
+        public UnclampedSynchronousSimulator(double syncSpeed, double motivity, double gamma, double smooth)
+        {
+            SyncSpeed = syncSpeed;
+            Motivity = motivity;
+            Gamma = gamma;
+            Sharpness = smooth <= 0 ? 100 : 0.5 / smooth;
+        }
+
+        public double SyncSpeed { get; }
+        public double Motivity { get; }
+        public double Gamma { get; }
+        public double Sharpness { get; }
+
+        public double Accelerate(double inputSpeed)
+        {
+            if (inputSpeed == SyncSpeed) return 1.0;
+
+            double logSyncSpeed = Math.Log(SyncSpeed);
+            double logMotivity = Math.Log(Motivity);
+            double gammaConst = Gamma / logMotivity;
+
+            double logX = Math.Log(inputSpeed);
+            double logDiff = logX - logSyncSpeed;
+
+            double logSpace = Math.Abs(gammaConst * logDiff);
+            double exponent = Math.Pow(Math.Tanh(Math.Pow(logSpace, Sharpness)), 1 / Sharpness);
+
+            exponent *= Math.Sign(logDiff);
+
+            return Math.Exp(exponent * logMotivity);
+        }
+    }
 
     /// <summary>
     /// Contains definition of how synchronous accel is expected to accelerate inputs

--- a/wrapper-tests/wrapper-tests.csproj
+++ b/wrapper-tests/wrapper-tests.csproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\packages\MSTest.TestAdapter.2.2.7\build\net45\MSTest.TestAdapter.props" Condition="Exists('..\packages\MSTest.TestAdapter.2.2.7\build\net45\MSTest.TestAdapter.props')" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />


### PR DESCRIPTION


I noticed the 'sharpness' logic has a threshold at 16 (around smooth = 0.03125) where it switches from the tanh formula to a linear clamp. I was curious if this transition was perfectly smooth, so I wrote a test to compare the driver's output against a pure math simulator that doesn't use the clamp.

Everything is working as expected with no jumps in sensitivity, so I'm submitting this as a safety net for future changes.

What's inside:
ThresholdTests.cs
: The new test file.
UnclampedSynchronousSimulator
: A simple class to check the "true" math against the driver's optimized version.
Verified everything with and without the threshold to ensure the tests are actually catching differences.