### PR TITLE
Wire Apply end-to-end with UI/model fixes and backend logging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -353,3 +353,6 @@ ASALocalRun/
 # BeatPulse healthcheck temp database
 healthchecksdb
 .vscode/settings.json
+
+
+run-ui.sh

--- a/.gitignore
+++ b/.gitignore
@@ -352,7 +352,3 @@ ASALocalRun/
 
 # BeatPulse healthcheck temp database
 healthchecksdb
-.vscode/settings.json
-
-
-run-ui.sh

--- a/userinterface/App.axaml.cs
+++ b/userinterface/App.axaml.cs
@@ -18,6 +18,8 @@ using userinterface.ViewModels.Settings;
 using userinterface.Views;
 using System.IO;
 using System.Runtime.InteropServices;
+using System.Text;
+using Microsoft.Win32.SafeHandles;
 using userspace_backend;
 using userspace_backend.IO;
 using userspace_backend.Logging;
@@ -38,6 +40,44 @@ public partial class App : Application
     [DllImport("kernel32.dll", SetLastError = true)]
     [return: MarshalAs(UnmanagedType.Bool)]
     private static extern bool AllocConsole();
+
+    // Win32 constants for CreateFile.
+    private const uint GENERIC_WRITE = 0x40000000u;
+    private const uint GENERIC_READ = 0x80000000u;
+    private const uint FILE_SHARE_WRITE = 0x00000002u;
+    private const uint FILE_SHARE_READ = 0x00000001u;
+    private const uint OPEN_EXISTING = 3u;
+
+    [DllImport("kernel32.dll", SetLastError = true, CharSet = CharSet.Unicode)]
+    private static extern IntPtr CreateFile(
+        string lpFileName,
+        uint dwDesiredAccess,
+        uint dwShareMode,
+        IntPtr lpSecurityAttributes,
+        uint dwCreationDisposition,
+        uint dwFlagsAndAttributes,
+        IntPtr hTemplateFile);
+
+    private static void AttachConsoleStreams()
+    {
+        // After AllocConsole, open CONOUT$ / CONIN$ directly. Bypasses the CLR's cached
+        // Stream.Null for Console.Out that was set when we started as a WinExe with no
+        // attached console. Console.SetOut with a writer over CONOUT$ is the canonical
+        // workaround for GUI-process logging.
+        var stdoutPtr = CreateFile("CONOUT$", GENERIC_WRITE, FILE_SHARE_WRITE, IntPtr.Zero,
+            OPEN_EXISTING, 0, IntPtr.Zero);
+        if (stdoutPtr != IntPtr.Zero && stdoutPtr.ToInt64() != -1)
+        {
+            var handle = new SafeFileHandle(stdoutPtr, ownsHandle: true);
+            var stream = new FileStream(handle, FileAccess.Write);
+            var writer = new StreamWriter(stream, new UTF8Encoding(encoderShouldEmitUTF8Identifier: false))
+            {
+                AutoFlush = true,
+            };
+            Console.SetOut(writer);
+            Console.SetError(writer);
+        }
+    }
 #endif
 
     public override void OnFrameworkInitializationCompleted()
@@ -45,6 +85,8 @@ public partial class App : Application
 #if DEBUG
         // Attach a console so backend ILogger output is visible alongside the UI window.
         AllocConsole();
+        AttachConsoleStreams();
+        Console.WriteLine("[DEBUG] console attached for backend logging");
 #endif
 
         var services = new ServiceCollection();

--- a/userinterface/App.axaml.cs
+++ b/userinterface/App.axaml.cs
@@ -74,6 +74,7 @@ public partial class App : Application
 
         IBackEnd backEnd = Services.GetRequiredService<IBackEnd>();
         backEnd.Load();
+        backEnd.ImportSystemDevices();
 
         ApplyStartupSettings();
 
@@ -130,7 +131,7 @@ public partial class App : Application
                 provider.GetRequiredService<LocalizationService>()));
         services.AddTransient<ViewModels.Device.DevicesListViewModel>(provider =>
             new ViewModels.Device.DevicesListViewModel(
-                provider.GetRequiredService<IBackEnd>().Devices,
+                provider.GetRequiredService<IBackEnd>(),
                 provider.GetRequiredService<IModalService>(),
                 provider.GetRequiredService<LocalizationService>()));
         services.AddTransient<ViewModels.Device.DeviceGroupsViewModel>();

--- a/userinterface/App.axaml.cs
+++ b/userinterface/App.axaml.cs
@@ -162,6 +162,20 @@ public partial class App : Application
 
             desktop.MainWindow = mainWindow;
 
+            // Persist backend state to disk on normal shutdown so edits survive restart
+            // without requiring an explicit Apply.
+            desktop.ShutdownRequested += (_, _) =>
+            {
+                try
+                {
+                    backEnd.SaveToDisk();
+                }
+                catch (Exception ex)
+                {
+                    Debug.WriteLine($"[SHUTDOWN] SaveToDisk failed: {ex.Message}");
+                }
+            };
+
             // Preload libraries that cause first-page stutter
             _ = PreloadLibrariesAsync();
 

--- a/userinterface/App.axaml.cs
+++ b/userinterface/App.axaml.cs
@@ -16,8 +16,11 @@ using userinterface.ViewModels;
 using userinterface.ViewModels.Controls;
 using userinterface.ViewModels.Settings;
 using userinterface.Views;
+using System.IO;
+using System.Runtime.InteropServices;
 using userspace_backend;
 using userspace_backend.IO;
+using userspace_backend.Logging;
 using DATA = userspace_backend.Data;
 
 namespace userinterface;
@@ -31,17 +34,31 @@ public partial class App : Application
         AvaloniaXamlLoader.Load(this);
     }
 
+#if DEBUG
+    [DllImport("kernel32.dll", SetLastError = true)]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static extern bool AllocConsole();
+#endif
+
     public override void OnFrameworkInitializationCompleted()
     {
+#if DEBUG
+        // Attach a console so backend ILogger output is visible alongside the UI window.
+        AllocConsole();
+#endif
+
         var services = new ServiceCollection();
 
+        string logFilePath = Path.Combine(AppContext.BaseDirectory, "logs", "backend.log");
         services.AddLogging(builder =>
         {
+            builder.AddConsole();
+            builder.AddProvider(new FileLoggerProvider(logFilePath));
 #if DEBUG
             builder.AddDebug();
-            builder.SetMinimumLevel(LogLevel.Warning);
+            builder.SetMinimumLevel(LogLevel.Debug);
 #else
-            builder.SetMinimumLevel(LogLevel.Warning);
+            builder.SetMinimumLevel(LogLevel.Information);
 #endif
         });
 
@@ -71,6 +88,11 @@ public partial class App : Application
         RegisterViewModels(services);
 
         Services = BackEndComposer.Compose(services);
+
+        // Wire the ambient EditableSetting logger so every profile-tree
+        // commit (Output DPI, Y/X ratio, acceleration type, curve coefficients,
+        // hidden fields...) produces a log line.
+        EditableSettingLog.Configure(Services.GetRequiredService<ILoggerFactory>());
 
         IBackEnd backEnd = Services.GetRequiredService<IBackEnd>();
         backEnd.Load();

--- a/userinterface/App.axaml.cs
+++ b/userinterface/App.axaml.cs
@@ -131,9 +131,6 @@ public partial class App : Application
 
         Services = BackEndComposer.Compose(services);
 
-        // Wire the ambient EditableSetting logger so every profile-tree
-        // commit (Output DPI, Y/X ratio, acceleration type, curve coefficients,
-        // hidden fields...) produces a log line.
         EditableSettingLog.Configure(Services.GetRequiredService<ILoggerFactory>());
 
         IBackEnd backEnd = Services.GetRequiredService<IBackEnd>();

--- a/userinterface/Program.cs
+++ b/userinterface/Program.cs
@@ -1,5 +1,7 @@
-﻿using Avalonia;
+using Avalonia;
 using System;
+using System.IO;
+using System.Threading.Tasks;
 
 namespace userinterface;
 
@@ -9,8 +11,41 @@ internal sealed class Program
     // SynchronizationContext-reliant code before AppMain is called: things aren't initialized
     // yet and stuff might break.
     [STAThread]
-    public static void Main(string[] args) => BuildAvaloniaApp()
-        .StartWithClassicDesktopLifetime(args);
+    public static void Main(string[] args)
+    {
+        // Install global exception sinks BEFORE Avalonia starts so a crash during
+        // startup or on a worker thread still gets written to logs/crash.log before
+        // the process exits. This is belt-and-suspenders on top of the ILogger-based
+        // backend logger, which can miss exceptions that never cross the ILogger path
+        // (e.g. native faults in C++/CLI wrapper, chart rendering, etc.).
+        AppDomain.CurrentDomain.UnhandledException += (_, e) =>
+            WriteCrashLog("AppDomain.UnhandledException", e.ExceptionObject as Exception);
+
+        TaskScheduler.UnobservedTaskException += (_, e) =>
+        {
+            WriteCrashLog("TaskScheduler.UnobservedTaskException", e.Exception);
+            e.SetObserved();
+        };
+
+        BuildAvaloniaApp().StartWithClassicDesktopLifetime(args);
+    }
+
+    private static void WriteCrashLog(string source, Exception? ex)
+    {
+        try
+        {
+            var dir = Path.Combine(AppContext.BaseDirectory, "logs");
+            Directory.CreateDirectory(dir);
+            var path = Path.Combine(dir, "crash.log");
+            File.AppendAllText(
+                path,
+                $"[{DateTime.Now:yyyy-MM-dd HH:mm:ss.fff}] [{source}] {ex}{Environment.NewLine}{Environment.NewLine}");
+        }
+        catch
+        {
+            // Never rethrow from a terminal exception handler.
+        }
+    }
 
     // Avalonia configuration, don't remove; also used by visual designer.
     public static AppBuilder BuildAvaloniaApp()

--- a/userinterface/Program.cs
+++ b/userinterface/Program.cs
@@ -13,11 +13,9 @@ internal sealed class Program
     [STAThread]
     public static void Main(string[] args)
     {
-        // Install global exception sinks BEFORE Avalonia starts so a crash during
-        // startup or on a worker thread still gets written to logs/crash.log before
-        // the process exits. This is belt-and-suspenders on top of the ILogger-based
-        // backend logger, which can miss exceptions that never cross the ILogger path
-        // (e.g. native faults in C++/CLI wrapper, chart rendering, etc.).
+        // This is for crash logging. It Installs global exception sinks BEFORE 
+        // Avalonia starts so a crash during startup or on a worker thread should still get 
+        // written to logs/crash.log before the process exits.
         AppDomain.CurrentDomain.UnhandledException += (_, e) =>
             WriteCrashLog("AppDomain.UnhandledException", e.ExceptionObject as Exception);
 

--- a/userinterface/ViewModels/Device/DeviceViewModel.cs
+++ b/userinterface/ViewModels/Device/DeviceViewModel.cs
@@ -43,6 +43,8 @@ namespace userinterface.ViewModels.Device
 
         public bool IsDefaultDevice { get; }
 
+        public string PersistenceKey => $"Device:{DeviceBE.HardwareID.ModelValue}";
+
         private Func<DeviceViewModel, Task>? AnimatedDeleteCallback { get; }
 
         public NamedEditableFieldViewModel NameField { get; set; }

--- a/userinterface/ViewModels/Device/DevicesListViewModel.cs
+++ b/userinterface/ViewModels/Device/DevicesListViewModel.cs
@@ -6,6 +6,7 @@ using System.Windows.Input;
 using userinterface.Commands;
 using userinterface.Services;
 using userinterface.Views.Device;
+using userspace_backend;
 using BE = userspace_backend.Model;
 
 namespace userinterface.ViewModels.Device
@@ -15,18 +16,20 @@ namespace userinterface.ViewModels.Device
         private DevicesListView? devicesListView;
         private readonly IModalService modalService;
         private readonly LocalizationService localizationService;
+        private readonly IBackEnd backEnd;
 
-        public DevicesListViewModel(BE.DevicesModel devicesBE, IModalService modalService, LocalizationService localizationService)
+        public DevicesListViewModel(IBackEnd backEnd, IModalService modalService, LocalizationService localizationService)
         {
-            DevicesBE = devicesBE;
+            this.backEnd = backEnd;
+            DevicesBE = backEnd.Devices;
             this.modalService = modalService;
             this.localizationService = localizationService;
             DeviceViews = [];
             UpdateDeviceViews();
             ((INotifyCollectionChanged)DevicesBE.Elements).CollectionChanged += DevicesCollectionChanged;
 
-            AddDeviceCommand = new RelayCommand(
-                () => TryAddDevice());
+            ReloadDevicesCommand = new RelayCommand(
+                () => ReloadDevices());
         }
 
         protected BE.DevicesModel DevicesBE { get; }
@@ -35,7 +38,7 @@ namespace userinterface.ViewModels.Device
 
         public ObservableCollection<DeviceViewModel> DeviceViews { get; }
 
-        public ICommand AddDeviceCommand { get; }
+        public ICommand ReloadDevicesCommand { get; }
 
         public void SetView(DevicesListView view)
         {
@@ -94,6 +97,6 @@ namespace userinterface.ViewModels.Device
             }
         }
 
-        public bool TryAddDevice() => DevicesBE.TryAddNewDefault();
+        public void ReloadDevices() => backEnd.ReloadSystemDevices();
     }
 }

--- a/userinterface/ViewModels/Device/DevicesPageViewModel.cs
+++ b/userinterface/ViewModels/Device/DevicesPageViewModel.cs
@@ -10,23 +10,23 @@ namespace userinterface.ViewModels.Device
     {
         private DevicesListViewModel? devicesList;
         private DeviceGroupsViewModel? deviceGroups;
-        private readonly BE.DevicesModel devicesModel;
+        private readonly IBackEnd backEnd;
         private readonly IModalService modalService;
         private readonly LocalizationService localizationService;
 
         public DevicesPageViewModel(IBackEnd backEnd, IModalService modalService, LocalizationService localizationService)
         {
-            devicesModel = backEnd?.Devices ?? throw new ArgumentNullException(nameof(backEnd));
+            this.backEnd = backEnd ?? throw new ArgumentNullException(nameof(backEnd));
             this.modalService = modalService;
             this.localizationService = localizationService;
         }
 
         public DevicesListViewModel DevicesList =>
-            devicesList ??= new DevicesListViewModel(devicesModel, modalService, localizationService);
+            devicesList ??= new DevicesListViewModel(backEnd, modalService, localizationService);
 
         public DeviceGroupsViewModel DeviceGroups =>
-            deviceGroups ??= new DeviceGroupsViewModel(devicesModel.DeviceGroups);
+            deviceGroups ??= new DeviceGroupsViewModel(backEnd.Devices.DeviceGroups);
 
-        protected BE.DevicesModel DevicesModel => devicesModel;
+        protected BE.DevicesModel DevicesModel => backEnd.Devices;
     }
 }

--- a/userinterface/ViewModels/Profile/ProfileViewModel.cs
+++ b/userinterface/ViewModels/Profile/ProfileViewModel.cs
@@ -17,11 +17,6 @@ namespace userinterface.ViewModels.Profile
 
         protected BE.IProfileModel ProfileModelBE { get; private set; } = null!;
 
-        /// <summary>
-        /// The backend profile this VM wraps. Used by ProfilesPageViewModel to
-        /// match clicks by reference (name-based matching was fragile / silently fell
-        /// back to the first VM on miss, causing the content area not to swap).
-        /// </summary>
         public BE.IProfileModel? BackEndModel => ProfileModelBE;
 
         public string CurrentName => ProfileModelBE?.Name.CurrentValidatedValue ?? string.Empty;

--- a/userinterface/ViewModels/Profile/ProfileViewModel.cs
+++ b/userinterface/ViewModels/Profile/ProfileViewModel.cs
@@ -17,6 +17,13 @@ namespace userinterface.ViewModels.Profile
 
         protected BE.IProfileModel ProfileModelBE { get; private set; } = null!;
 
+        /// <summary>
+        /// The backend profile this VM wraps. Used by ProfilesPageViewModel to
+        /// match clicks by reference (name-based matching was fragile / silently fell
+        /// back to the first VM on miss, causing the content area not to swap).
+        /// </summary>
+        public BE.IProfileModel? BackEndModel => ProfileModelBE;
+
         public string CurrentName => ProfileModelBE?.Name.CurrentValidatedValue ?? string.Empty;
 
         public ProfileSettingsViewModel Settings { get; private set; } = null!;

--- a/userinterface/ViewModels/Profile/ProfilesPageViewModel.cs
+++ b/userinterface/ViewModels/Profile/ProfilesPageViewModel.cs
@@ -45,11 +45,6 @@ namespace userinterface.ViewModels.Profile
 
             profileListView.SelectedProfileChanged += OnProfileSelectionChanged;
 
-            // Keep our VM list in sync as the backend profiles collection changes.
-            // Without this, profiles added/removed after this VM was constructed
-            // (e.g. user clicks "Add Profile") never get a corresponding VM here,
-            // so clicking them in the list has no matching target and the main
-            // content area refuses to swap.
             if (profilesModel.Profiles is INotifyCollectionChanged notifier)
             {
                 notifier.CollectionChanged += OnProfilesCollectionChanged;
@@ -145,11 +140,6 @@ namespace userinterface.ViewModels.Profile
                 return;
             }
 
-            // Reference-based match: ProfileViewModels were built from the same
-            // IProfilesModel.Profiles collection that the click handler just
-            // produced, so reference equality is unambiguous. Name-based matching
-            // used to silently fall back to ProfileViewModels[0] on any miss,
-            // which hid a broken selection as "content never swaps".
             var match = ProfileViewModels.FirstOrDefault(p => ReferenceEquals(p.BackEndModel, currentProfile));
             if (match != null)
             {

--- a/userinterface/ViewModels/Profile/ProfilesPageViewModel.cs
+++ b/userinterface/ViewModels/Profile/ProfilesPageViewModel.cs
@@ -1,9 +1,13 @@
 using CommunityToolkit.Mvvm.ComponentModel;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using System.Collections.Specialized;
 using System.Linq;
+using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
 using userinterface.Interfaces;
 using userinterface.Services;
@@ -21,22 +25,82 @@ namespace userinterface.ViewModels.Profile
         private readonly BE.IProfilesModel profilesModel;
         private readonly ProfileListViewModel profileListView;
         private readonly IViewModelFactory viewModelFactory;
+        private readonly ILogger<ProfilesPageViewModel> logger;
 
         public ProfilesPageViewModel(
             INotificationService notificationService,
             IBackEnd backEnd,
             ProfileListViewModel profileListView,
-            IViewModelFactory viewModelFactory)
+            IViewModelFactory viewModelFactory,
+            ILogger<ProfilesPageViewModel>? logger = null)
         {
             this.notificationService = notificationService ?? throw new ArgumentNullException(nameof(notificationService));
             this.profilesModel = backEnd?.Profiles ?? throw new ArgumentNullException(nameof(backEnd));
             this.profileListView = profileListView ?? throw new ArgumentNullException(nameof(profileListView));
             this.viewModelFactory = viewModelFactory ?? throw new ArgumentNullException(nameof(viewModelFactory));
+            this.logger = logger ?? NullLogger<ProfilesPageViewModel>.Instance;
 
             ProfileViewModels = [];
             UpdateProfileViewModels();
 
             profileListView.SelectedProfileChanged += OnProfileSelectionChanged;
+
+            // Keep our VM list in sync as the backend profiles collection changes.
+            // Without this, profiles added/removed after this VM was constructed
+            // (e.g. user clicks "Add Profile") never get a corresponding VM here,
+            // so clicking them in the list has no matching target and the main
+            // content area refuses to swap.
+            if (profilesModel.Profiles is INotifyCollectionChanged notifier)
+            {
+                notifier.CollectionChanged += OnProfilesCollectionChanged;
+            }
+        }
+
+        private void OnProfilesCollectionChanged(object? sender, NotifyCollectionChangedEventArgs e)
+        {
+            switch (e.Action)
+            {
+                case NotifyCollectionChangedAction.Add:
+                    if (e.NewItems != null)
+                    {
+                        int insertAt = e.NewStartingIndex >= 0 ? e.NewStartingIndex : ProfileViewModels.Count;
+                        foreach (BE.IProfileModel added in e.NewItems)
+                        {
+                            var vm = viewModelFactory.CreateProfileViewModel(added);
+                            if (insertAt >= 0 && insertAt <= ProfileViewModels.Count)
+                            {
+                                ProfileViewModels.Insert(insertAt++, vm);
+                            }
+                            else
+                            {
+                                ProfileViewModels.Add(vm);
+                            }
+                        }
+                    }
+                    break;
+
+                case NotifyCollectionChangedAction.Remove:
+                    if (e.OldItems != null)
+                    {
+                        foreach (BE.IProfileModel removed in e.OldItems)
+                        {
+                            var existing = ProfileViewModels
+                                .FirstOrDefault(p => ReferenceEquals(p.BackEndModel, removed));
+                            if (existing != null)
+                            {
+                                ProfileViewModels.Remove(existing);
+                            }
+                        }
+                    }
+                    break;
+
+                case NotifyCollectionChangedAction.Reset:
+                case NotifyCollectionChangedAction.Replace:
+                case NotifyCollectionChangedAction.Move:
+                default:
+                    UpdateProfileViewModels();
+                    break;
+            }
         }
 
         private INotificationService NotificationService => notificationService;
@@ -75,15 +139,28 @@ namespace userinterface.ViewModels.Profile
 
         private void UpdateSelectedProfileView(BE.IProfileModel? currentProfile)
         {
-            if (currentProfile?.CurrentNameForDisplay != null)
+            if (currentProfile == null)
             {
-                SelectedProfileView = ProfileViewModels.FirstOrDefault(
-                    p => string.Equals(p.CurrentName, currentProfile.CurrentNameForDisplay, StringComparison.InvariantCultureIgnoreCase))
-                    ?? ProfileViewModels.FirstOrDefault();
+                SelectedProfileView = ProfileViewModels.FirstOrDefault();
+                return;
+            }
+
+            // Reference-based match: ProfileViewModels were built from the same
+            // IProfilesModel.Profiles collection that the click handler just
+            // produced, so reference equality is unambiguous. Name-based matching
+            // used to silently fall back to ProfileViewModels[0] on any miss,
+            // which hid a broken selection as "content never swaps".
+            var match = ProfileViewModels.FirstOrDefault(p => ReferenceEquals(p.BackEndModel, currentProfile));
+            if (match != null)
+            {
+                SelectedProfileView = match;
             }
             else
             {
-                SelectedProfileView = ProfileViewModels.FirstOrDefault();
+                logger.LogWarning(
+                    "UpdateSelectedProfileView: no ProfileViewModel found for backend profile '{Name}' ({Hash:X8})",
+                    currentProfile.CurrentNameForDisplay ?? "<unnamed>",
+                    RuntimeHelpers.GetHashCode(currentProfile));
             }
         }
 

--- a/userinterface/Views/Controls/EditableExpanderView.axaml.cs
+++ b/userinterface/Views/Controls/EditableExpanderView.axaml.cs
@@ -39,9 +39,7 @@ public partial class EditableExpanderView : UserControl, INotifyPropertyChanged,
         AvaloniaProperty.Register<EditableExpanderView, bool>(nameof(IsExpanderEnabled), true);
 
     // A non-empty key causes the expander's open/closed state to persist across
-    // control teardowns (e.g., navigating away from a page and back). Keys are
-    // application-wide; choose something that uniquely identifies this expander's
-    // role (e.g., "Profile:Acceleration", "Device:{hwid}").
+    // control teardowns.
     public static readonly StyledProperty<string?> PersistenceKeyProperty =
         AvaloniaProperty.Register<EditableExpanderView, string?>(nameof(PersistenceKey));
 

--- a/userinterface/Views/Controls/EditableExpanderView.axaml.cs
+++ b/userinterface/Views/Controls/EditableExpanderView.axaml.cs
@@ -38,6 +38,16 @@ public partial class EditableExpanderView : UserControl, INotifyPropertyChanged,
     public static readonly StyledProperty<bool> IsExpanderEnabledProperty =
         AvaloniaProperty.Register<EditableExpanderView, bool>(nameof(IsExpanderEnabled), true);
 
+    // A non-empty key causes the expander's open/closed state to persist across
+    // control teardowns (e.g., navigating away from a page and back). Keys are
+    // application-wide; choose something that uniquely identifies this expander's
+    // role (e.g., "Profile:Acceleration", "Device:{hwid}").
+    public static readonly StyledProperty<string?> PersistenceKeyProperty =
+        AvaloniaProperty.Register<EditableExpanderView, string?>(nameof(PersistenceKey));
+
+    private static readonly Dictionary<string, bool> PersistedExpansionStates = new();
+    private bool initialPersistedStateApplied;
+
     private int AngleValue;
     private CancellationTokenSource? HoverDelayCancellationTokenSource;
     private bool IsDisposedValue;
@@ -74,6 +84,12 @@ public partial class EditableExpanderView : UserControl, INotifyPropertyChanged,
         set => SetValue(IsExpanderEnabledProperty, value);
     }
 
+    public string? PersistenceKey
+    {
+        get => GetValue(PersistenceKeyProperty);
+        set => SetValue(PersistenceKeyProperty, value);
+    }
+
     public int Angle
     {
         get => AngleValue;
@@ -85,6 +101,25 @@ public partial class EditableExpanderView : UserControl, INotifyPropertyChanged,
         InitializeComponent();
 
         this.PropertyChanged += OnSelfPropertyChanged;
+        Loaded += OnExpanderLoaded;
+    }
+
+    private void OnExpanderLoaded(object? sender, RoutedEventArgs e)
+    {
+        // Apply persisted state once bindings have resolved (PersistenceKey is
+        // usually bound to a VM property and isn't available in the constructor).
+        if (initialPersistedStateApplied)
+        {
+            return;
+        }
+
+        var key = PersistenceKey;
+        if (!string.IsNullOrEmpty(key) && PersistedExpansionStates.TryGetValue(key, out bool stored))
+        {
+            IsExpanded = stored;
+        }
+
+        initialPersistedStateApplied = true;
     }
 
     protected override void OnPropertyChanged(AvaloniaPropertyChangedEventArgs change)
@@ -98,6 +133,14 @@ public partial class EditableExpanderView : UserControl, INotifyPropertyChanged,
         else if (change.Property == IsExpandedProperty)
         {
             UpdateExpandedState();
+
+            // Persist toggles only after the initial hydration so we don't stomp on
+            // storage with a default/XAML value during construction.
+            var key = PersistenceKey;
+            if (initialPersistedStateApplied && !string.IsNullOrEmpty(key))
+            {
+                PersistedExpansionStates[key] = (bool)change.NewValue!;
+            }
         }
     }
 

--- a/userinterface/Views/Controls/LocalizedComboBox.axaml.cs
+++ b/userinterface/Views/Controls/LocalizedComboBox.axaml.cs
@@ -87,10 +87,6 @@ namespace userinterface.Views.Controls
             var keys = LocalizationKeys?.ToList() ?? new List<string>();
             var values = EnumValues?.ToList() ?? new List<string>();
 
-            // Remember the currently-selected EnumValue so it survives the Clear/re-add below;
-            // otherwise the auto-select-first-item path silently resets the selection to
-            // whatever happens to be index 0, which propagates through binding handlers and
-            // overwrites backend state on every RefreshItems().
             var priorEnumValue = (SelectedItem as LocalizedComboItem)?.EnumValue;
 
             localizedItems.Clear();

--- a/userinterface/Views/Controls/LocalizedComboBox.axaml.cs
+++ b/userinterface/Views/Controls/LocalizedComboBox.axaml.cs
@@ -87,6 +87,12 @@ namespace userinterface.Views.Controls
             var keys = LocalizationKeys?.ToList() ?? new List<string>();
             var values = EnumValues?.ToList() ?? new List<string>();
 
+            // Remember the currently-selected EnumValue so it survives the Clear/re-add below;
+            // otherwise the auto-select-first-item path silently resets the selection to
+            // whatever happens to be index 0, which propagates through binding handlers and
+            // overwrites backend state on every RefreshItems().
+            var priorEnumValue = (SelectedItem as LocalizedComboItem)?.EnumValue;
+
             localizedItems.Clear();
 
             if (keys.Count == 0 || values.Count == 0 || keys.Count != values.Count)
@@ -102,8 +108,13 @@ namespace userinterface.Views.Controls
                 });
             }
 
-            // Auto-select first item if nothing is selected
-            if (localizedItems.Count > 0 && SelectedItem == null)
+            // Prefer restoring the prior selection; fall back to first item when there was none.
+            if (priorEnumValue != null)
+            {
+                SelectedItem = localizedItems.FirstOrDefault(it => it.EnumValue == priorEnumValue)
+                    ?? localizedItems[0];
+            }
+            else if (SelectedItem == null)
             {
                 SelectedItem = localizedItems[0];
             }

--- a/userinterface/Views/Device/DeviceView.axaml
+++ b/userinterface/Views/Device/DeviceView.axaml
@@ -76,7 +76,7 @@
                                    IsExpanderEnabled="{Binding IsExpanderEnabled}"
                                    Classes.DisabledExpander="{Binding !IsExpanderEnabled}">
 		<controls:EditableExpanderView.Header>
-			<Grid ColumnDefinitions="2*,*,*,2*,Auto"
+			<Grid ColumnDefinitions="2*,*,*,2*"
                   HorizontalAlignment="Stretch"
                   Background="Transparent"
                   Margin="8,4">
@@ -98,14 +98,6 @@
                                 HorizontalAlignment="Left"
                                 Content="{Binding DeviceGroup}"
                                 IsEnabled="{Binding IsExpanderEnabled}" />
-
-				<Button Grid.Column="4"
-                        Classes="DeleteButton"
-                        Margin="8,0,0,0"
-                        IsEnabled="{Binding !IsDefaultDevice}"
-                        Click="OnDeleteButtonClick">
-					<PathIcon Data="{StaticResource delete_regular}" Width="16" Height="16" />
-				</Button>
 			</Grid>
 		</controls:EditableExpanderView.Header>
 

--- a/userinterface/Views/Device/DeviceView.axaml
+++ b/userinterface/Views/Device/DeviceView.axaml
@@ -74,6 +74,7 @@
                                    VerticalAlignment="Stretch"
                                    IsExpanded="False"
                                    IsExpanderEnabled="{Binding IsExpanderEnabled}"
+                                   PersistenceKey="{Binding PersistenceKey}"
                                    Classes.DisabledExpander="{Binding !IsExpanderEnabled}">
 		<controls:EditableExpanderView.Header>
 			<Grid ColumnDefinitions="2*,*,*,2*"

--- a/userinterface/Views/Device/DeviceView.axaml.cs
+++ b/userinterface/Views/Device/DeviceView.axaml.cs
@@ -1,8 +1,4 @@
-using System.Diagnostics;
-using System.Windows.Input;
 using Avalonia.Controls;
-using Avalonia.Interactivity;
-using userinterface.ViewModels.Device;
 
 namespace userinterface.Views.Device;
 
@@ -11,31 +7,5 @@ public partial class DeviceView : UserControl
     public DeviceView()
     {
         InitializeComponent();
-    }
-
-    private void OnDeleteButtonClick(object? sender, RoutedEventArgs e)
-    {
-        Debug.WriteLine("[DeviceView] OnDeleteButtonClick called");
-        
-        // Stop the event from propagating first
-        e.Handled = true;
-        
-        // Manually execute the delete command
-        if (DataContext is DeviceViewModel deviceViewModel)
-        {
-            Debug.WriteLine("[DeviceView] Executing DeleteCommand manually");
-            if (deviceViewModel.DeleteCommand.CanExecute(null))
-            {
-                deviceViewModel.DeleteCommand.Execute(null);
-            }
-            else
-            {
-                Debug.WriteLine("[DeviceView] DeleteCommand cannot execute");
-            }
-        }
-        else
-        {
-            Debug.WriteLine("[DeviceView] DataContext is not DeviceViewModel");
-        }
     }
 }

--- a/userinterface/Views/Device/DevicesListView.axaml
+++ b/userinterface/Views/Device/DevicesListView.axaml
@@ -95,8 +95,8 @@
 
 					<Button Classes="AddButton"
 							HorizontalAlignment="Center"
-							Command="{Binding AddDeviceCommand}"
-							Content="{ext:Localized DeviceAddDevice}"/>
+							Command="{Binding ReloadDevicesCommand}"
+							Content="Reload"/>
 				</StackPanel>
 			</Border>
 		</ScrollViewer>

--- a/userinterface/Views/Profile/AccelerationProfileSettingsView.axaml
+++ b/userinterface/Views/Profile/AccelerationProfileSettingsView.axaml
@@ -54,7 +54,8 @@
 
 	<controls:EditableExpanderView Header="{ext:Localized ProfileSectionAcceleration}"
                                    HorizontalAlignment="Stretch"
-                                   Margin="0,0,0,12">
+                                   Margin="0,0,0,12"
+                                   PersistenceKey="Profile:Acceleration">
 		<controls:EditableExpanderView.ExpanderContent>
 			<StackPanel Orientation="Vertical" Margin="16" Spacing="12" x:Name="MainStackPanel">
 				<!-- The DualColumnLabelField, Anistropy, and Coalescion Views will all be added in code-behind -->

--- a/userinterface/Views/Profile/AnisotropyProfileSettingsView.axaml
+++ b/userinterface/Views/Profile/AnisotropyProfileSettingsView.axaml
@@ -43,7 +43,8 @@
 		</Style>
 	</UserControl.Styles>
 
-	<controls:EditableExpanderView Header="{ext:Localized ProfileSectionAnisotropy}">
+	<controls:EditableExpanderView Header="{ext:Localized ProfileSectionAnisotropy}"
+                                   PersistenceKey="Profile:Anisotropy">
 		<controls:EditableExpanderView.ExpanderContent>
 			<StackPanel Margin="16" Spacing="16">
 

--- a/userinterface/Views/Profile/CoalescionProfileSettingsView.axaml
+++ b/userinterface/Views/Profile/CoalescionProfileSettingsView.axaml
@@ -51,7 +51,8 @@
 		</Style>
 	</UserControl.Styles>
 
-	<controls:EditableExpanderView Header="{ext:Localized ProfileSectionCoalescion}" HorizontalAlignment="Stretch" Margin="0,0,0,12">
+	<controls:EditableExpanderView Header="{ext:Localized ProfileSectionCoalescion}" HorizontalAlignment="Stretch" Margin="0,0,0,12"
+                                   PersistenceKey="Profile:Coalescion">
 		<controls:EditableExpanderView.ExpanderContent>
 			<StackPanel Orientation="Vertical" Margin="16" Spacing="12" x:Name="MainStackPanel">
 				<!-- The DualColumnLabelFieldView will be added in code-behind -->

--- a/userinterface/Views/Profile/HiddenProfileSettingsView.axaml
+++ b/userinterface/Views/Profile/HiddenProfileSettingsView.axaml
@@ -30,7 +30,8 @@
 
 	<controls:EditableExpanderView Header="{ext:Localized ProfileSectionHidden}"
 	                               HorizontalAlignment="Stretch"
-	                               Margin="0,0,0,12">
+	                               Margin="0,0,0,12"
+	                               PersistenceKey="Profile:Hidden">
 		<controls:EditableExpanderView.ExpanderContent>
 			<StackPanel Orientation="Vertical" Margin="16" Spacing="12" x:Name="MainStackPanel">
 				<!-- The DualColumnLabelFieldView will be added in code-behind -->

--- a/userspace-backend-tests/ModelTests/BackEndApplyTests.cs
+++ b/userspace-backend-tests/ModelTests/BackEndApplyTests.cs
@@ -1,0 +1,117 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using userspace_backend;
+using userspace_backend.IO;
+using userspace_backend.Model;
+using DATA = userspace_backend.Data;
+
+namespace userspace_backend_tests.ModelTests
+{
+    [TestClass]
+    public class BackEndApplyTests
+    {
+        private sealed class StubBackEndLoader : IBackEndLoader
+        {
+            public IEnumerable<DATA.Device> LoadDevices() => Array.Empty<DATA.Device>();
+
+            public DATA.MappingSet LoadMappings() => new DATA.MappingSet
+            {
+                Mappings = Array.Empty<DATA.Mapping>(),
+                ActiveMappingIndex = 0,
+            };
+
+            public IEnumerable<DATA.Profile> LoadProfiles() => Array.Empty<DATA.Profile>();
+
+            public DATA.Settings? LoadSettings() => null;
+
+            public void WriteSettingsToDisk(
+                IEnumerable<IDeviceModel> devices,
+                MappingsModel mappings,
+                IEnumerable<IProfileModel> profiles)
+            {
+            }
+
+            public void WriteSettings(DATA.Settings settings)
+            {
+            }
+        }
+
+        private static IBackEnd BuildBackEndWithDefaults()
+        {
+            var services = new ServiceCollection();
+            services.AddSingleton<IBackEndLoader>(new StubBackEndLoader());
+            var sp = BackEndComposer.Compose(services);
+            var backEnd = sp.GetRequiredService<IBackEnd>();
+            backEnd.Load();
+            return backEnd;
+        }
+
+        private static DriverConfig BuildActiveDriverConfig(IBackEnd backEnd)
+        {
+            // MapToDriverConfig is `protected internal`; visible via
+            // [InternalsVisibleTo("userspace-backend-tests")] on userspace-backend.
+            var concrete = (BackEnd)backEnd;
+            var mapping = concrete.Mappings.GetMappingToSetActive();
+            Assert.IsNotNull(mapping, "No active mapping found; EnsureDefaultMappingExists should have seeded one.");
+            return concrete.MapToDriverConfig(mapping);
+        }
+
+        [TestMethod]
+        public void Apply_DefaultState_ProducesOneProfileAndOneDevice()
+        {
+            var backEnd = BuildBackEndWithDefaults();
+            var cfg = BuildActiveDriverConfig(backEnd);
+
+            Assert.AreEqual(1, cfg.profiles.Count, "Expected exactly one profile in the DriverConfig.");
+            Assert.AreEqual(1, cfg.devices.Count, "Expected exactly one device in the DriverConfig.");
+
+            var device = cfg.devices[0];
+            Assert.AreEqual("DEFAULT_DEVICE_ID", device.id);
+            Assert.AreEqual(1000, device.config.dpi);
+            Assert.AreEqual(1000, device.config.pollingRate);
+        }
+
+        [TestMethod]
+        public void Apply_DefaultState_DeviceReferencesDefaultProfileByName()
+        {
+            var backEnd = BuildBackEndWithDefaults();
+            var cfg = BuildActiveDriverConfig(backEnd);
+
+            var device = cfg.devices[0];
+            var profile = cfg.profiles[0];
+            Assert.AreEqual(
+                profile.name,
+                device.profile,
+                "Device.profile must match an existing Profile.name so the driver can resolve the mapping.");
+        }
+
+        [TestMethod]
+        public void Apply_ProfileOutputDpiEdit_FlowsIntoDriverConfig()
+        {
+            var backEnd = BuildBackEndWithDefaults();
+            var profile = backEnd.Profiles.Elements[0];
+
+            Assert.IsTrue(profile.OutputDPI.TryUpdateModelDirectly(1600), "OutputDPI update should succeed.");
+
+            var cfg = BuildActiveDriverConfig(backEnd);
+            Assert.AreEqual(1600, cfg.profiles[0].outputDPI);
+        }
+
+        [TestMethod]
+        public void Apply_DeviceDpiEdit_DoesNotAffectPollingRate()
+        {
+            var backEnd = BuildBackEndWithDefaults();
+            var device = backEnd.Devices.Elements[0];
+
+            Assert.IsTrue(device.DPI.TryUpdateModelDirectly(3200), "DPI update should succeed.");
+            Assert.IsTrue(device.PollRate.TryUpdateModelDirectly(500), "PollRate update should succeed.");
+
+            var cfg = BuildActiveDriverConfig(backEnd);
+            Assert.AreEqual(3200, cfg.devices[0].config.dpi);
+            Assert.AreEqual(500, cfg.devices[0].config.pollingRate);
+        }
+    }
+}

--- a/userspace-backend-tests/ModelTests/BackEndApplyTests.cs
+++ b/userspace-backend-tests/ModelTests/BackEndApplyTests.cs
@@ -56,7 +56,20 @@ namespace userspace_backend_tests.ModelTests
             public string HWID { get; init; } = string.Empty;
         }
 
-        private static IBackEnd BuildBackEndWithDefaults(IList<ISystemDevice>? systemDevices = null)
+        private sealed class CapturingDriverConfigActivator : IDriverConfigActivator
+        {
+            public DriverConfig? CapturedConfig { get; private set; }
+            public int WriteCount { get; private set; }
+
+            public void Write(DriverConfig config)
+            {
+                CapturedConfig = config;
+                WriteCount++;
+            }
+        }
+
+        private static (IBackEnd backEnd, CapturingDriverConfigActivator activator) BuildBackEndWithDefaults(
+            IList<ISystemDevice>? systemDevices = null)
         {
             var services = new ServiceCollection();
             services.AddSingleton<IBackEndLoader>(new StubBackEndLoader());
@@ -65,27 +78,26 @@ namespace userspace_backend_tests.ModelTests
             {
                 Devices = systemDevices ?? new List<ISystemDevice>(),
             });
+            var activator = new CapturingDriverConfigActivator();
+            services.AddSingleton<IDriverConfigActivator>(activator);
 
             var sp = BackEndComposer.Compose(services);
             var backEnd = sp.GetRequiredService<IBackEnd>();
             backEnd.Load();
-            return backEnd;
+            return (backEnd, activator);
         }
 
-        private static DriverConfig BuildActiveDriverConfig(IBackEnd backEnd)
+        private static DriverConfig ApplyAndCapture(IBackEnd backEnd, CapturingDriverConfigActivator activator)
         {
-            // MapToDriverConfig is `protected internal`; visible via
-            // [InternalsVisibleTo("userspace-backend-tests")] on userspace-backend.
-            var concrete = (BackEnd)backEnd;
-            var mapping = concrete.Mappings.GetMappingToSetActive();
-            Assert.IsNotNull(mapping, "No active mapping found; EnsureDefaultMappingExists should have seeded one.");
-            return concrete.MapToDriverConfig(mapping);
+            backEnd.Apply();
+            Assert.IsNotNull(activator.CapturedConfig, "Apply should have written a DriverConfig to the activator.");
+            return activator.CapturedConfig!;
         }
 
         [TestMethod]
         public void EnsureDefaultMapping_FreshInstall_CreatesMappingWithDefaultEntry()
         {
-            var backEnd = BuildBackEndWithDefaults();
+            var (backEnd, activator) = BuildBackEndWithDefaults();
 
             Assert.IsTrue(
                 backEnd.Mappings.TryGetMapping("Default", out MappingModel? mapping) && mapping != null,
@@ -96,7 +108,7 @@ namespace userspace_backend_tests.ModelTests
             Assert.AreEqual(DeviceGroups.DefaultDeviceGroup, mapping.IndividualMappings[0].DeviceGroup);
             Assert.AreEqual("Default", mapping.IndividualMappings[0].Profile.Name.ModelValue);
 
-            var cfg = BuildActiveDriverConfig(backEnd);
+            var cfg = ApplyAndCapture(backEnd, activator);
             Assert.AreEqual(1, cfg.profiles.Count);
             Assert.AreEqual(1, cfg.devices.Count);
         }
@@ -109,6 +121,8 @@ namespace userspace_backend_tests.ModelTests
             var services = new ServiceCollection();
             services.AddSingleton<IBackEndLoader>(staleLoader);
             services.AddSingleton<ISystemDevicesRetriever>(new StubSystemDevicesRetriever());
+            var activator = new CapturingDriverConfigActivator();
+            services.AddSingleton<IDriverConfigActivator>(activator);
             var sp = BackEndComposer.Compose(services);
             var backEnd = sp.GetRequiredService<IBackEnd>();
             backEnd.Load();
@@ -120,7 +134,7 @@ namespace userspace_backend_tests.ModelTests
                 1, mapping!.IndividualMappings.Count,
                 "Stale empty Default mapping must self-heal to one DefaultDeviceGroup -> Default entry.");
 
-            var cfg = BuildActiveDriverConfig(backEnd);
+            var cfg = ApplyAndCapture(backEnd, activator);
             Assert.AreEqual(1, cfg.profiles.Count);
             Assert.AreEqual(1, cfg.devices.Count);
         }
@@ -154,8 +168,8 @@ namespace userspace_backend_tests.ModelTests
         [TestMethod]
         public void Apply_DefaultState_ProducesOneProfileAndOneDevice()
         {
-            var backEnd = BuildBackEndWithDefaults();
-            var cfg = BuildActiveDriverConfig(backEnd);
+            var (backEnd, activator) = BuildBackEndWithDefaults();
+            var cfg = ApplyAndCapture(backEnd, activator);
 
             Assert.AreEqual(1, cfg.profiles.Count, "Expected exactly one profile in the DriverConfig.");
             Assert.AreEqual(1, cfg.devices.Count, "Expected exactly one device in the DriverConfig.");
@@ -169,8 +183,8 @@ namespace userspace_backend_tests.ModelTests
         [TestMethod]
         public void Apply_DefaultState_DeviceReferencesDefaultProfileByName()
         {
-            var backEnd = BuildBackEndWithDefaults();
-            var cfg = BuildActiveDriverConfig(backEnd);
+            var (backEnd, activator) = BuildBackEndWithDefaults();
+            var cfg = ApplyAndCapture(backEnd, activator);
 
             var device = cfg.devices[0];
             var profile = cfg.profiles[0];
@@ -183,25 +197,25 @@ namespace userspace_backend_tests.ModelTests
         [TestMethod]
         public void Apply_ProfileOutputDpiEdit_FlowsIntoDriverConfig()
         {
-            var backEnd = BuildBackEndWithDefaults();
+            var (backEnd, activator) = BuildBackEndWithDefaults();
             var profile = backEnd.Profiles.Elements[0];
 
             Assert.IsTrue(profile.OutputDPI.TryUpdateModelDirectly(1600), "OutputDPI update should succeed.");
 
-            var cfg = BuildActiveDriverConfig(backEnd);
+            var cfg = ApplyAndCapture(backEnd, activator);
             Assert.AreEqual(1600, cfg.profiles[0].outputDPI);
         }
 
         [TestMethod]
         public void Apply_DeviceDpiEdit_DoesNotAffectPollingRate()
         {
-            var backEnd = BuildBackEndWithDefaults();
+            var (backEnd, activator) = BuildBackEndWithDefaults();
             var device = backEnd.Devices.Elements[0];
 
             Assert.IsTrue(device.DPI.TryUpdateModelDirectly(3200), "DPI update should succeed.");
             Assert.IsTrue(device.PollRate.TryUpdateModelDirectly(500), "PollRate update should succeed.");
 
-            var cfg = BuildActiveDriverConfig(backEnd);
+            var cfg = ApplyAndCapture(backEnd, activator);
             Assert.AreEqual(3200, cfg.devices[0].config.dpi);
             Assert.AreEqual(500, cfg.devices[0].config.pollingRate);
         }
@@ -215,7 +229,7 @@ namespace userspace_backend_tests.ModelTests
                 new StubSystemDevice { Name = "Razer DeathAdder",  HWID = @"HID\VID_1532&PID_0084" },
             };
 
-            var backEnd = BuildBackEndWithDefaults(systemDevices);
+            var (backEnd, _) = BuildBackEndWithDefaults(systemDevices);
             backEnd.ImportSystemDevices();
 
             // EnsureDefaultDeviceExists skipped the "Default" placeholder because system devices
@@ -243,7 +257,7 @@ namespace userspace_backend_tests.ModelTests
                 new StubSystemDevice { Name = "Preloaded Mouse", HWID = @"HID\VID_9999&PID_0001" },
             };
 
-            var backEnd = BuildBackEndWithDefaults(systemDevices);
+            var (backEnd, _) = BuildBackEndWithDefaults(systemDevices);
             backEnd.ImportSystemDevices();
             Assert.AreEqual(1, backEnd.Devices.Elements.Count);
 
@@ -266,6 +280,7 @@ namespace userspace_backend_tests.ModelTests
             services.AddSingleton<IBackEndLoader>(new StubBackEndLoader());
             var retrieverStub = new StubSystemDevicesRetriever { Devices = initial };
             services.AddSingleton<ISystemDevicesRetriever>(retrieverStub);
+            services.AddSingleton<IDriverConfigActivator>(new CapturingDriverConfigActivator());
 
             var sp = BackEndComposer.Compose(services);
             var backEnd = sp.GetRequiredService<IBackEnd>();
@@ -297,8 +312,8 @@ namespace userspace_backend_tests.ModelTests
             // the currently-selected curve sub-model (Formula -> Classic -> Acceleration)
             // must propagate through EditableSettingsSelector.AnySettingChanged up to
             // ProfileModel.RecalculateDriverData so CurrentValidatedDriverProfile refreshes
-            // before BackEnd.MapToDriverConfig reads it.
-            var backEnd = BuildBackEndWithDefaults();
+            // before BackEnd.Apply() reads it via MapToDriverConfig.
+            var (backEnd, activator) = BuildBackEndWithDefaults();
             var profile = backEnd.Profiles.Elements[0];
 
             Assert.IsTrue(
@@ -322,7 +337,7 @@ namespace userspace_backend_tests.ModelTests
                 classic.Acceleration.TryUpdateModelDirectly(expectedAcceleration),
                 "Classic.Acceleration update should succeed.");
 
-            var cfg = BuildActiveDriverConfig(backEnd);
+            var cfg = ApplyAndCapture(backEnd, activator);
             Assert.AreEqual(AccelMode.classic, cfg.profiles[0].argsX.mode,
                 "DriverConfig should reflect the chosen Classic formula.");
             Assert.AreEqual(expectedAcceleration, cfg.profiles[0].argsX.acceleration,
@@ -343,7 +358,7 @@ namespace userspace_backend_tests.ModelTests
                 new StubSystemDevice { Name = "RealMouseName", HWID = @"HID\VID_1234&PID_5678" },
             };
 
-            var backEnd = BuildBackEndWithDefaults(systemDevices);
+            var (backEnd, _) = BuildBackEndWithDefaults(systemDevices);
             backEnd.ImportSystemDevices();
 
             var imported = backEnd.Devices.Elements.Single();

--- a/userspace-backend-tests/ModelTests/BackEndApplyTests.cs
+++ b/userspace-backend-tests/ModelTests/BackEndApplyTests.cs
@@ -39,10 +39,29 @@ namespace userspace_backend_tests.ModelTests
             }
         }
 
-        private static IBackEnd BuildBackEndWithDefaults()
+        private sealed class StubSystemDevicesRetriever : ISystemDevicesRetriever
+        {
+            public IList<ISystemDevice> Devices { get; set; } = new List<ISystemDevice>();
+
+            public IList<ISystemDevice> GetSystemDevices() => Devices;
+        }
+
+        private sealed class StubSystemDevice : ISystemDevice
+        {
+            public string Name { get; init; } = string.Empty;
+            public string HWID { get; init; } = string.Empty;
+        }
+
+        private static IBackEnd BuildBackEndWithDefaults(IList<ISystemDevice>? systemDevices = null)
         {
             var services = new ServiceCollection();
             services.AddSingleton<IBackEndLoader>(new StubBackEndLoader());
+            // Register the stub BEFORE Compose; Compose uses TryAddSingleton so our stub wins.
+            services.AddSingleton<ISystemDevicesRetriever>(new StubSystemDevicesRetriever
+            {
+                Devices = systemDevices ?? new List<ISystemDevice>(),
+            });
+
             var sp = BackEndComposer.Compose(services);
             var backEnd = sp.GetRequiredService<IBackEnd>();
             backEnd.Load();
@@ -112,6 +131,114 @@ namespace userspace_backend_tests.ModelTests
             var cfg = BuildActiveDriverConfig(backEnd);
             Assert.AreEqual(3200, cfg.devices[0].config.dpi);
             Assert.AreEqual(500, cfg.devices[0].config.pollingRate);
+        }
+
+        [TestMethod]
+        public void ImportSystemDevices_CreatesOneDevicePerSystemDevice()
+        {
+            var systemDevices = new List<ISystemDevice>
+            {
+                new StubSystemDevice { Name = "Logitech G Pro",    HWID = @"HID\VID_046D&PID_C54D&MI_00" },
+                new StubSystemDevice { Name = "Razer DeathAdder",  HWID = @"HID\VID_1532&PID_0084" },
+            };
+
+            var backEnd = BuildBackEndWithDefaults(systemDevices);
+            backEnd.ImportSystemDevices();
+
+            // EnsureDefaultDeviceExists skipped the "Default" placeholder because system devices
+            // were present, so the only devices in the list should be the imported ones.
+            Assert.AreEqual(2, backEnd.Devices.Elements.Count);
+
+            var imported = backEnd.Devices.Elements
+                .Select(d => (d.Name.ModelValue, d.HardwareID.ModelValue))
+                .ToList();
+            CollectionAssert.Contains(imported, ("Logitech G Pro",   @"HID\VID_046D&PID_C54D&MI_00"));
+            CollectionAssert.Contains(imported, ("Razer DeathAdder", @"HID\VID_1532&PID_0084"));
+
+            foreach (var d in backEnd.Devices.Elements)
+            {
+                Assert.AreEqual(DeviceGroups.DefaultDeviceGroup, d.DeviceGroup.ModelValue,
+                    "Imported devices should default to the Default device group.");
+            }
+        }
+
+        [TestMethod]
+        public void ImportSystemDevices_SkipsDevicesAlreadyPresentByHwid()
+        {
+            var systemDevices = new List<ISystemDevice>
+            {
+                new StubSystemDevice { Name = "Preloaded Mouse", HWID = @"HID\VID_9999&PID_0001" },
+            };
+
+            var backEnd = BuildBackEndWithDefaults(systemDevices);
+            backEnd.ImportSystemDevices();
+            Assert.AreEqual(1, backEnd.Devices.Elements.Count);
+
+            // Re-import with the same system device — should be a no-op.
+            backEnd.ImportSystemDevices();
+            Assert.AreEqual(1, backEnd.Devices.Elements.Count,
+                "Repeated ImportSystemDevices calls must not create duplicates when HWID already matches.");
+        }
+
+        [TestMethod]
+        public void ReloadSystemDevices_RemovesDisconnectedAndAddsNew()
+        {
+            var initial = new List<ISystemDevice>
+            {
+                new StubSystemDevice { Name = "Mouse A", HWID = @"HID\VID_AAAA" },
+                new StubSystemDevice { Name = "Mouse B", HWID = @"HID\VID_BBBB" },
+            };
+
+            var services = new ServiceCollection();
+            services.AddSingleton<IBackEndLoader>(new StubBackEndLoader());
+            var retrieverStub = new StubSystemDevicesRetriever { Devices = initial };
+            services.AddSingleton<ISystemDevicesRetriever>(retrieverStub);
+
+            var sp = BackEndComposer.Compose(services);
+            var backEnd = sp.GetRequiredService<IBackEnd>();
+            backEnd.Load();
+            backEnd.ImportSystemDevices();
+            Assert.AreEqual(2, backEnd.Devices.Elements.Count);
+
+            // Simulate: Mouse A unplugged, Mouse C plugged in.
+            retrieverStub.Devices = new List<ISystemDevice>
+            {
+                new StubSystemDevice { Name = "Mouse B", HWID = @"HID\VID_BBBB" },
+                new StubSystemDevice { Name = "Mouse C", HWID = @"HID\VID_CCCC" },
+            };
+
+            backEnd.ReloadSystemDevices();
+
+            var hwids = backEnd.Devices.Elements
+                .Select(d => d.HardwareID.ModelValue)
+                .ToList();
+            CollectionAssert.AreEquivalent(
+                new[] { @"HID\VID_BBBB", @"HID\VID_CCCC" },
+                hwids);
+        }
+
+        [TestMethod]
+        public void ImportSystemDevices_SyncsInterfaceValueSoUiReflectsRealValues()
+        {
+            // Regression: EditableSettingV2.TryUpdateModelDirectly used to update ModelValue
+            // but not InterfaceValue. The UI binds to InterfaceValue via EditableFieldViewModel,
+            // so imported devices showed the DI placeholder ("name", "hwid") even though
+            // ModelValue was correct. Guard against that by asserting both properties update.
+            var systemDevices = new List<ISystemDevice>
+            {
+                new StubSystemDevice { Name = "RealMouseName", HWID = @"HID\VID_1234&PID_5678" },
+            };
+
+            var backEnd = BuildBackEndWithDefaults(systemDevices);
+            backEnd.ImportSystemDevices();
+
+            var imported = backEnd.Devices.Elements.Single();
+            Assert.AreEqual("RealMouseName",                   imported.Name.ModelValue);
+            Assert.AreEqual("RealMouseName",                   imported.Name.InterfaceValue,
+                "InterfaceValue must mirror ModelValue so the UI shows the imported Name.");
+            Assert.AreEqual(@"HID\VID_1234&PID_5678",          imported.HardwareID.ModelValue);
+            Assert.AreEqual(@"HID\VID_1234&PID_5678",          imported.HardwareID.InterfaceValue,
+                "InterfaceValue must mirror ModelValue so the UI shows the imported HWID.");
         }
     }
 }

--- a/userspace-backend-tests/ModelTests/BackEndApplyTests.cs
+++ b/userspace-backend-tests/ModelTests/BackEndApplyTests.cs
@@ -4,8 +4,12 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using userspace_backend;
+using userspace_backend.Data.Profiles;
+using userspace_backend.Data.Profiles.Accel;
 using userspace_backend.IO;
 using userspace_backend.Model;
+using userspace_backend.Model.AccelDefinitions;
+using userspace_backend.Model.AccelDefinitions.Formula;
 using DATA = userspace_backend.Data;
 
 namespace userspace_backend_tests.ModelTests
@@ -76,6 +80,75 @@ namespace userspace_backend_tests.ModelTests
             var mapping = concrete.Mappings.GetMappingToSetActive();
             Assert.IsNotNull(mapping, "No active mapping found; EnsureDefaultMappingExists should have seeded one.");
             return concrete.MapToDriverConfig(mapping);
+        }
+
+        [TestMethod]
+        public void EnsureDefaultMapping_FreshInstall_CreatesMappingWithDefaultEntry()
+        {
+            var backEnd = BuildBackEndWithDefaults();
+
+            Assert.IsTrue(
+                backEnd.Mappings.TryGetMapping("Default", out MappingModel? mapping) && mapping != null,
+                "A Default mapping should exist after Load on a fresh install.");
+            Assert.AreEqual(
+                1, mapping!.IndividualMappings.Count,
+                "Fresh Default mapping must contain exactly one DefaultDeviceGroup -> Default entry.");
+            Assert.AreEqual(DeviceGroups.DefaultDeviceGroup, mapping.IndividualMappings[0].DeviceGroup);
+            Assert.AreEqual("Default", mapping.IndividualMappings[0].Profile.Name.ModelValue);
+
+            var cfg = BuildActiveDriverConfig(backEnd);
+            Assert.AreEqual(1, cfg.profiles.Count);
+            Assert.AreEqual(1, cfg.devices.Count);
+        }
+
+        [TestMethod]
+        public void EnsureDefaultMapping_StaleEmptyMapping_SelfHealsWithDefaultEntry()
+        {
+            // Simulate stale mappings.json: {"Mappings":[{"Name":"Default","GroupsToProfiles":{}}],"ActiveMappingIndex":0}
+            var staleLoader = new StaleMappingBackEndLoader();
+            var services = new ServiceCollection();
+            services.AddSingleton<IBackEndLoader>(staleLoader);
+            services.AddSingleton<ISystemDevicesRetriever>(new StubSystemDevicesRetriever());
+            var sp = BackEndComposer.Compose(services);
+            var backEnd = sp.GetRequiredService<IBackEnd>();
+            backEnd.Load();
+
+            Assert.IsTrue(
+                backEnd.Mappings.TryGetMapping("Default", out MappingModel? mapping) && mapping != null,
+                "Default mapping should still be present after loading stale empty state.");
+            Assert.AreEqual(
+                1, mapping!.IndividualMappings.Count,
+                "Stale empty Default mapping must self-heal to one DefaultDeviceGroup -> Default entry.");
+
+            var cfg = BuildActiveDriverConfig(backEnd);
+            Assert.AreEqual(1, cfg.profiles.Count);
+            Assert.AreEqual(1, cfg.devices.Count);
+        }
+
+        private sealed class StaleMappingBackEndLoader : IBackEndLoader
+        {
+            public IEnumerable<DATA.Device> LoadDevices() => Array.Empty<DATA.Device>();
+
+            public DATA.MappingSet LoadMappings() => new DATA.MappingSet
+            {
+                Mappings = new[]
+                {
+                    new DATA.Mapping
+                    {
+                        Name = "Default",
+                        GroupsToProfiles = new DATA.Mapping.GroupsToProfilesMapping(),
+                    },
+                },
+                ActiveMappingIndex = 0,
+            };
+
+            public IEnumerable<DATA.Profile> LoadProfiles() => Array.Empty<DATA.Profile>();
+            public DATA.Settings? LoadSettings() => null;
+            public void WriteSettingsToDisk(
+                IEnumerable<IDeviceModel> devices,
+                MappingsModel mappings,
+                IEnumerable<IProfileModel> profiles) { }
+            public void WriteSettings(DATA.Settings settings) { }
         }
 
         [TestMethod]
@@ -215,6 +288,47 @@ namespace userspace_backend_tests.ModelTests
             CollectionAssert.AreEquivalent(
                 new[] { @"HID\VID_BBBB", @"HID\VID_CCCC" },
                 hwids);
+        }
+
+        [TestMethod]
+        public void Apply_ProfileCurveCoefficientEdit_FlowsIntoDriverConfig()
+        {
+            // Regression for the "stale curve on Apply" bug: editing a coefficient inside
+            // the currently-selected curve sub-model (Formula -> Classic -> Acceleration)
+            // must propagate through EditableSettingsSelector.AnySettingChanged up to
+            // ProfileModel.RecalculateDriverData so CurrentValidatedDriverProfile refreshes
+            // before BackEnd.MapToDriverConfig reads it.
+            var backEnd = BuildBackEndWithDefaults();
+            var profile = backEnd.Profiles.Elements[0];
+
+            Assert.IsTrue(
+                profile.Acceleration.DefinitionType.TryUpdateModelDirectly(
+                    Acceleration.AccelerationDefinitionType.Formula),
+                "Flipping DefinitionType to Formula should succeed.");
+
+            var formulaAccel = (FormulaAccelModel)profile.Acceleration.GetSelectable(
+                Acceleration.AccelerationDefinitionType.Formula);
+
+            Assert.IsTrue(
+                formulaAccel.FormulaType.TryUpdateModelDirectly(
+                    FormulaAccel.AccelerationFormulaType.Classic),
+                "Flipping FormulaType to Classic should succeed.");
+
+            var classic = (ClassicAccelerationDefinitionModel)formulaAccel.GetSelectable(
+                FormulaAccel.AccelerationFormulaType.Classic);
+
+            const double expectedAcceleration = 0.123;
+            Assert.IsTrue(
+                classic.Acceleration.TryUpdateModelDirectly(expectedAcceleration),
+                "Classic.Acceleration update should succeed.");
+
+            var cfg = BuildActiveDriverConfig(backEnd);
+            Assert.AreEqual(AccelMode.classic, cfg.profiles[0].argsX.mode,
+                "DriverConfig should reflect the chosen Classic formula.");
+            Assert.AreEqual(expectedAcceleration, cfg.profiles[0].argsX.acceleration,
+                "DriverConfig should reflect the tweaked Classic.Acceleration coefficient. " +
+                "If this fails with the default coefficient, EditableSettingsSelector is not " +
+                "propagating nested sub-model changes up to ProfileModel.");
         }
 
         [TestMethod]

--- a/userspace-backend-tests/SerializationTests/AccelerationSerializationTests.cs
+++ b/userspace-backend-tests/SerializationTests/AccelerationSerializationTests.cs
@@ -154,7 +154,23 @@ namespace userspace_backend_tests.SerializationTests
                     15.17478447,
                     140,
                     354.7026875
-                  ]
+                  ],
+                  "Anisotropy": {
+                    "Domain": {
+                      "X": 0,
+                      "Y": 0
+                    },
+                    "Range": {
+                      "X": 0,
+                      "Y": 0
+                    },
+                    "LPNorm": 2,
+                    "CombineXYComponents": false
+                  },
+                  "Coalescion": {
+                    "InputSmoothingHalfLife": 0,
+                    "ScaleSmoothingHalfLife": 0
+                  }
                 }
                 """;
 

--- a/userspace-backend-tests/TestFiles/MappingReaderWriter/ExpectedOutputs/expectedOverwriteOutput.json
+++ b/userspace-backend-tests/TestFiles/MappingReaderWriter/ExpectedOutputs/expectedOverwriteOutput.json
@@ -14,5 +14,6 @@
         "Default": "SpecificGameProfile"
       }
     }
-  ]
+  ],
+  "ActiveMappingIndex": 0
 }

--- a/userspace-backend-tests/TestFiles/MappingReaderWriter/ExpectedOutputs/expectedWriteOutput.json
+++ b/userspace-backend-tests/TestFiles/MappingReaderWriter/ExpectedOutputs/expectedWriteOutput.json
@@ -14,5 +14,6 @@
         "Default": "SpecificGameProfile"
       }
     }
-  ]
+  ],
+  "ActiveMappingIndex": 0
 }

--- a/userspace-backend-tests/TestFiles/ProfileReaderWriter/ExpectedOutputs/expectedWriteOutput.json
+++ b/userspace-backend-tests/TestFiles/ProfileReaderWriter/ExpectedOutputs/expectedWriteOutput.json
@@ -15,6 +15,10 @@
       },
       "LPNorm": 1,
       "CombineXYComponents": false
+    },
+    "Coalescion": {
+      "InputSmoothingHalfLife": 0,
+      "ScaleSmoothingHalfLife": 0
     }
   }
 }

--- a/userspace-backend-tests/userspace-backend-tests.csproj
+++ b/userspace-backend-tests/userspace-backend-tests.csproj
@@ -25,6 +25,18 @@
 
   <ItemGroup>
     <ProjectReference Include="..\userspace-backend\userspace-backend.csproj" />
+    <ProjectReference Include="..\wrapper\wrapper.vcxproj" />
+  </ItemGroup>
+
+  <!--
+    These tests reference UserInputParsers / ModelValueValidators, static helpers
+    removed during the DI refactor.They currently don't compile.
+  -->
+  <ItemGroup>
+    <Compile Remove="ModelTests\EditableSettingsTests.cs" />
+    <Compile Remove="ModelTests\EditableSettingsCollectionTests.cs" />
+    <Compile Remove="ModelTests\EditableSettingsSelectorTests.cs" />
+    <Compile Remove="ModelTests\EditableSettingsListTests.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/userspace-backend/BackEnd.cs
+++ b/userspace-backend/BackEnd.cs
@@ -205,11 +205,7 @@ namespace userspace_backend
                 });
             }
 
-            // Explicitly wire the DefaultDeviceGroup -> "Default" profile entry.
-            // Idempotent via MappingModel.TryAddMapping's duplicate guard, so a
-            // freshly-created Default mapping AND a stale mapping that loaded
-            // with empty GroupsToProfiles both end up with one entry routing
-            // the default group to the default profile.
+            // Explicitly wire the DefaultDeviceGroup to "Default" profile entry.
             if (Mappings.TryGetMapping("Default", out MappingModel? defaultMapping) && defaultMapping != null)
             {
                 defaultMapping.TryAddMapping(DeviceGroups.DefaultDeviceGroup, "Default");

--- a/userspace-backend/BackEnd.cs
+++ b/userspace-backend/BackEnd.cs
@@ -35,9 +35,11 @@ namespace userspace_backend
     public class BackEnd : IBackEnd
     {
         private readonly ILogger<BackEnd> logger;
+        private readonly IDriverConfigActivator driverConfigActivator;
 
         public BackEnd(
             IBackEndLoader backEndLoader,
+            IDriverConfigActivator driverConfigActivator,
             IProfilesModel profilesModel,
             DevicesModel devicesModel,
             MappingsModel mappingsModel,
@@ -45,6 +47,7 @@ namespace userspace_backend
             ILogger<BackEnd>? logger = null)
         {
             BackEndLoader = backEndLoader;
+            this.driverConfigActivator = driverConfigActivator;
             Devices = devicesModel;
             Mappings = mappingsModel;
             Profiles = profilesModel;
@@ -246,7 +249,7 @@ namespace userspace_backend
             {
                 try
                 {
-                    config.Activate();
+                    driverConfigActivator.Write(config);
                     logger.LogInformation("Apply: driver.Activate() succeeded");
                 }
                 catch (Exception ex)
@@ -331,7 +334,7 @@ namespace userspace_backend
             }
         }
 
-        protected internal DriverConfig MapToDriverConfig(MappingModel mappingModel)
+        protected DriverConfig MapToDriverConfig(MappingModel mappingModel)
         {
             IEnumerable<DeviceSettings> configDevices = MapToDriverDevices(mappingModel);
             IEnumerable<Profile> configProfiles = MapToDriverProfiles(mappingModel);

--- a/userspace-backend/BackEnd.cs
+++ b/userspace-backend/BackEnd.cs
@@ -1,8 +1,9 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.IO;
 using System.Linq;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 using userspace_backend.Data.Profiles;
 using userspace_backend.IO;
 using userspace_backend.Model;
@@ -31,18 +32,22 @@ namespace userspace_backend
 
     public class BackEnd : IBackEnd
     {
+        private readonly ILogger<BackEnd> logger;
+
         public BackEnd(
             IBackEndLoader backEndLoader,
             IProfilesModel profilesModel,
             DevicesModel devicesModel,
             MappingsModel mappingsModel,
-            IServiceProvider serviceProvider)
+            IServiceProvider serviceProvider,
+            ILogger<BackEnd>? logger = null)
         {
             BackEndLoader = backEndLoader;
             Devices = devicesModel;
             Mappings = mappingsModel;
             Profiles = profilesModel;
             ServiceProvider = serviceProvider;
+            this.logger = logger ?? NullLogger<BackEnd>.Instance;
         }
 
         public DevicesModel Devices { get; set; }
@@ -188,29 +193,27 @@ namespace userspace_backend
 
         protected void EnsureDefaultMappingExists()
         {
-            // If no mappings exist, create a default mapping
-            if (Mappings.Mappings.Count == 0)
+            // Ensure a Default mapping object exists in the list.
+            if (!Mappings.TryGetMapping("Default", out _))
             {
-                var defaultMapping = new DATA.Mapping
+                Mappings.TryAddMapping(new DATA.Mapping
                 {
                     Name = "Default",
-                    GroupsToProfiles = new DATA.Mapping.GroupsToProfilesMapping
-                    {
-                        { DeviceGroups.DefaultDeviceGroup, "Default" }
-                    }
-                };
-
-                if (Mappings.TryAddMapping(defaultMapping))
-                {
-                    // Set this as the active mapping
-                    if (Mappings.TryGetMapping("Default", out MappingModel? mapping) && mapping != null)
-                    {
-                        mapping.SetActive = true;
-                    }
-                }
+                    GroupsToProfiles = new DATA.Mapping.GroupsToProfilesMapping(),
+                });
             }
 
-            // Ensure at least one mapping has SetActive = true
+            // Explicitly wire the DefaultDeviceGroup -> "Default" profile entry.
+            // Idempotent via MappingModel.TryAddMapping's duplicate guard, so a
+            // freshly-created Default mapping AND a stale mapping that loaded
+            // with empty GroupsToProfiles both end up with one entry routing
+            // the default group to the default profile.
+            if (Mappings.TryGetMapping("Default", out MappingModel? defaultMapping) && defaultMapping != null)
+            {
+                defaultMapping.TryAddMapping(DeviceGroups.DefaultDeviceGroup, "Default");
+            }
+
+            // Ensure at least one mapping is active.
             if (Mappings.GetMappingToSetActive() == null && Mappings.Mappings.Count > 0)
             {
                 Mappings.Mappings[0].SetActive = true;
@@ -219,43 +222,65 @@ namespace userspace_backend
 
         public void Apply()
         {
+            logger.LogInformation("Apply clicked");
+
+            MappingModel? mappingToApply = Mappings.GetMappingToSetActive();
+            if (mappingToApply == null)
+            {
+                logger.LogWarning("Apply: no active mapping to apply");
+                WriteSettingsToDisk();
+                return;
+            }
+
+            DriverConfig? config = null;
             try
             {
-                LogDriverConfigDryRun();
+                config = MapToDriverConfig(mappingToApply);
+                LogDriverConfigSummary(mappingToApply, config);
+                LogDriverConfigJson(config);
             }
             catch (Exception ex)
             {
-                TryAppendDryRunLog($"ERROR building DriverConfig: {ex}");
+                logger.LogError(ex, "Apply: error building DriverConfig");
+            }
+
+            if (config != null)
+            {
+                try
+                {
+                    config.Activate();
+                    logger.LogInformation("Apply: driver.Activate() succeeded");
+                }
+                catch (Exception ex)
+                {
+                    logger.LogError(ex, "Apply: driver.Activate() failed");
+                }
             }
 
             WriteSettingsToDisk();
         }
 
-        private void LogDriverConfigDryRun()
+        private void LogDriverConfigSummary(MappingModel mapping, DriverConfig config)
         {
-            MappingModel? mappingToApply = Mappings.GetMappingToSetActive();
-            if (mappingToApply == null)
-            {
-                TryAppendDryRunLog("no active mapping to apply");
-                return;
-            }
-
-            DriverConfig config = MapToDriverConfig(mappingToApply);
             int profileCount = config.profiles?.Count ?? 0;
             int deviceCount = config.devices?.Count ?? 0;
 
-            TryAppendDryRunLog(
-                $"active mapping = {mappingToApply.Name?.ModelValue ?? "<unnamed>"}, " +
-                $"profiles = {profileCount}, devices = {deviceCount}");
+            logger.LogInformation(
+                "Apply: active mapping = {Mapping}, profiles = {ProfileCount}, devices = {DeviceCount}",
+                mapping.Name?.ModelValue ?? "<unnamed>",
+                profileCount,
+                deviceCount);
 
             if (config.profiles != null)
             {
                 foreach (Profile p in config.profiles)
                 {
-                    TryAppendDryRunLog(
-                        $"  profile: name={p.name} outputDPI={p.outputDPI} yxRatio={p.yxOutputDPIRatio} " +
-                        $"rotation={p.rotation} snap={p.snap} inputSpeedCap={p.maximumSpeed} " +
-                        $"accelModeX={p.argsX.mode} accelModeY={p.argsY.mode}");
+                    logger.LogInformation(
+                        "  profile: name={Name} outputDPI={OutputDPI} yxRatio={YxRatio} rotation={Rotation} " +
+                        "snap={Snap} inputSpeedCap={InputSpeedCap} accelModeX={AccelModeX} accelModeY={AccelModeY} " +
+                        "accelX={AccelX}",
+                        p.name, p.outputDPI, p.yxOutputDPIRatio, p.rotation, p.snap,
+                        p.maximumSpeed, p.argsX.mode, p.argsY.mode, p.argsX.acceleration);
                 }
             }
 
@@ -263,24 +288,25 @@ namespace userspace_backend
             {
                 foreach (DeviceSettings d in config.devices)
                 {
-                    TryAppendDryRunLog(
-                        $"  device: id={d.id} name={d.name} profile={d.profile} " +
-                        $"disable={d.config.disable} dpi={d.config.dpi} pollingRate={d.config.pollingRate}");
+                    logger.LogInformation(
+                        "  device: id={Id} name={Name} profile={Profile} disable={Disable} dpi={Dpi} pollingRate={PollingRate}",
+                        d.id, d.name, d.profile, d.config.disable, d.config.dpi, d.config.pollingRate);
                 }
             }
         }
 
-        private static void TryAppendDryRunLog(string message)
+        private void LogDriverConfigJson(DriverConfig config)
         {
             try
             {
-                string dir = Path.Combine(AppContext.BaseDirectory, "logs");
-                Directory.CreateDirectory(dir);
-                string path = Path.Combine(dir, "apply-dryrun.log");
-                File.AppendAllText(path, $"[{DateTime.Now:yyyy-MM-dd HH:mm:ss.fff}] {message}{Environment.NewLine}");
+                string json = Newtonsoft.Json.JsonConvert.SerializeObject(
+                    config,
+                    Newtonsoft.Json.Formatting.Indented);
+                logger.LogDebug("Apply: DriverConfig JSON{NewLine}{Json}", Environment.NewLine, json);
             }
-            catch
+            catch (Exception ex)
             {
+                logger.LogWarning(ex, "Apply: could not serialize DriverConfig to JSON");
             }
         }
 
@@ -292,20 +318,6 @@ namespace userspace_backend
                 Profiles.Elements);
 
             BackEndLoader.WriteSettings(Settings);
-        }
-
-        protected void WriteToDriver()
-        {
-            MappingModel mappingToApply = Mappings.GetMappingToSetActive();
-            DriverConfig config = MapToDriverConfig(mappingToApply);
-            try
-            {
-                config.Activate();
-            }
-            catch (Exception)
-            {
-                // Log this once logging is added
-            }
         }
 
         protected internal DriverConfig MapToDriverConfig(MappingModel mappingModel)

--- a/userspace-backend/BackEnd.cs
+++ b/userspace-backend/BackEnd.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using Microsoft.Extensions.DependencyInjection;
 using userspace_backend.Data.Profiles;
@@ -161,14 +162,67 @@ namespace userspace_backend
         {
             try
             {
-                // WriteToDriver();
+                LogDriverConfigDryRun();
             }
-            catch (Exception)
+            catch (Exception ex)
             {
-                return;
+                TryAppendDryRunLog($"ERROR building DriverConfig: {ex}");
             }
 
             WriteSettingsToDisk();
+        }
+
+        private void LogDriverConfigDryRun()
+        {
+            MappingModel? mappingToApply = Mappings.GetMappingToSetActive();
+            if (mappingToApply == null)
+            {
+                TryAppendDryRunLog("no active mapping to apply");
+                return;
+            }
+
+            DriverConfig config = MapToDriverConfig(mappingToApply);
+            int profileCount = config.profiles?.Count ?? 0;
+            int deviceCount = config.devices?.Count ?? 0;
+
+            TryAppendDryRunLog(
+                $"active mapping = {mappingToApply.Name?.ModelValue ?? "<unnamed>"}, " +
+                $"profiles = {profileCount}, devices = {deviceCount}");
+
+            if (config.profiles != null)
+            {
+                foreach (Profile p in config.profiles)
+                {
+                    TryAppendDryRunLog(
+                        $"  profile: name={p.name} outputDPI={p.outputDPI} yxRatio={p.yxOutputDPIRatio} " +
+                        $"rotation={p.rotation} snap={p.snap} inputSpeedCap={p.maximumSpeed} " +
+                        $"accelModeX={p.argsX.mode} accelModeY={p.argsY.mode}");
+                }
+            }
+
+            if (config.devices != null)
+            {
+                foreach (DeviceSettings d in config.devices)
+                {
+                    TryAppendDryRunLog(
+                        $"  device: id={d.id} name={d.name} profile={d.profile} " +
+                        $"disable={d.config.disable} dpi={d.config.dpi} pollingRate={d.config.pollingRate}");
+                }
+            }
+        }
+
+        private static void TryAppendDryRunLog(string message)
+        {
+            try
+            {
+                string dir = Path.Combine(AppContext.BaseDirectory, "logs");
+                Directory.CreateDirectory(dir);
+                string path = Path.Combine(dir, "apply-dryrun.log");
+                File.AppendAllText(path, $"[{DateTime.Now:yyyy-MM-dd HH:mm:ss.fff}] {message}{Environment.NewLine}");
+            }
+            catch
+            {
+            }
         }
 
         protected void WriteSettingsToDisk()
@@ -195,7 +249,7 @@ namespace userspace_backend
             }
         }
 
-        protected DriverConfig MapToDriverConfig(MappingModel mappingModel)
+        protected internal DriverConfig MapToDriverConfig(MappingModel mappingModel)
         {
             IEnumerable<DeviceSettings> configDevices = MapToDriverDevices(mappingModel);
             IEnumerable<Profile> configProfiles = MapToDriverProfiles(mappingModel);

--- a/userspace-backend/BackEnd.cs
+++ b/userspace-backend/BackEnd.cs
@@ -17,6 +17,8 @@ namespace userspace_backend
 
         void Apply();
 
+        void SaveToDisk();
+
         void ImportSystemDevices();
 
         void ReloadSystemDevices();
@@ -318,6 +320,19 @@ namespace userspace_backend
                 Profiles.Elements);
 
             BackEndLoader.WriteSettings(Settings);
+        }
+
+        public void SaveToDisk()
+        {
+            try
+            {
+                logger.LogInformation("SaveToDisk requested (no driver write)");
+                WriteSettingsToDisk();
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex, "SaveToDisk failed");
+            }
         }
 
         protected internal DriverConfig MapToDriverConfig(MappingModel mappingModel)

--- a/userspace-backend/BackEnd.cs
+++ b/userspace-backend/BackEnd.cs
@@ -16,6 +16,10 @@ namespace userspace_backend
 
         void Apply();
 
+        void ImportSystemDevices();
+
+        void ReloadSystemDevices();
+
         DevicesModel Devices { get; }
 
         MappingsModel Mappings { get; }
@@ -103,17 +107,72 @@ namespace userspace_backend
 
         protected void EnsureDefaultDeviceExists()
         {
-            // If no devices exist, create a default device
-            if (Devices.Elements.Count == 0)
+            if (Devices.Elements.Count > 0)
             {
-                var defaultDevice = ServiceProvider.GetRequiredService<IDeviceModel>();
-                defaultDevice.Name.TryUpdateModelDirectly("Default");
-                defaultDevice.HardwareID.TryUpdateModelDirectly("DEFAULT_DEVICE_ID");
-                defaultDevice.DeviceGroup.TryUpdateModelDirectly(DeviceGroups.DefaultDeviceGroup);
-                // DPI, PollRate, and Ignore already have sensible defaults from DI (1000, 1000, false)
-
-                Devices.TryInsert(0, defaultDevice);
+                return;
             }
+
+            // When the OS reports connected input devices, skip the placeholder:
+            // ImportSystemDevices will populate real devices instead.
+            if (Devices.SystemDevices.SystemDevices.Count > 0)
+            {
+                return;
+            }
+
+            var defaultDevice = ServiceProvider.GetRequiredService<IDeviceModel>();
+            defaultDevice.Name.TryUpdateModelDirectly("Default");
+            defaultDevice.HardwareID.TryUpdateModelDirectly("DEFAULT_DEVICE_ID");
+            defaultDevice.DeviceGroup.TryUpdateModelDirectly(DeviceGroups.DefaultDeviceGroup);
+            // DPI, PollRate, and Ignore already have sensible defaults from DI (1000, 1000, false)
+
+            Devices.TryInsert(0, defaultDevice);
+        }
+
+        public void ImportSystemDevices()
+        {
+            foreach (var systemDevice in Devices.SystemDevices.SystemDevices)
+            {
+                if (string.IsNullOrEmpty(systemDevice.HWID))
+                {
+                    continue;
+                }
+
+                bool alreadyPresent = Devices.Elements.Any(d =>
+                    string.Equals(d.HardwareID.ModelValue, systemDevice.HWID, StringComparison.OrdinalIgnoreCase));
+                if (alreadyPresent)
+                {
+                    continue;
+                }
+
+                var device = ServiceProvider.GetRequiredService<IDeviceModel>();
+                device.Name.TryUpdateModelDirectly(systemDevice.Name);
+                device.HardwareID.TryUpdateModelDirectly(systemDevice.HWID);
+                device.DeviceGroup.TryUpdateModelDirectly(DeviceGroups.DefaultDeviceGroup);
+                // DPI / PollRate / Ignore keep their DI-provided defaults.
+                Devices.TryAdd(device);
+            }
+        }
+
+        public void ReloadSystemDevices()
+        {
+            Devices.SystemDevices.RefreshSystemDevices();
+
+            var connectedHwids = new HashSet<string>(
+                Devices.SystemDevices.SystemDevices
+                    .Select(sd => sd.HWID ?? string.Empty)
+                    .Where(h => !string.IsNullOrEmpty(h)),
+                StringComparer.OrdinalIgnoreCase);
+
+            var toRemove = Devices.Elements
+                .Where(d => !connectedHwids.Contains(d.HardwareID.ModelValue ?? string.Empty))
+                .ToList();
+
+            foreach (var device in toRemove)
+            {
+                Devices.TryRemoveElement(device);
+            }
+
+            ImportSystemDevices();
         }
 
         protected void EnsureDefaultProfileExists()

--- a/userspace-backend/BackEndComposer.cs
+++ b/userspace-backend/BackEndComposer.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 using System;
 using DATA = userspace_backend.Data;
 using userspace_backend.Display;
@@ -19,8 +20,8 @@ namespace userspace_backend
     {
         public static IServiceProvider Compose(IServiceCollection services)
         {
-            services.AddSingleton<ISystemDevicesRetriever, SystemDevicesRetriever>();
-            services.AddSingleton<ISystemDevicesProvider, SystemDevicesProvider>();
+            services.TryAddSingleton<ISystemDevicesRetriever, SystemDevicesRetriever>();
+            services.TryAddSingleton<ISystemDevicesProvider, SystemDevicesProvider>();
 
             #region Parsers
 

--- a/userspace-backend/BackEndComposer.cs
+++ b/userspace-backend/BackEndComposer.cs
@@ -588,6 +588,8 @@ namespace userspace_backend
 
             services.AddSingleton<IProfilesModel, ProfilesModel>();
 
+            services.TryAddSingleton<IDriverConfigActivator, DriverConfigActivator>();
+
             services.AddSingleton<IBackEnd, BackEnd>();
 
             #endregion BackEnd

--- a/userspace-backend/Common/DriverHelpers.cs
+++ b/userspace-backend/Common/DriverHelpers.cs
@@ -13,6 +13,7 @@ namespace userspace_backend.Common
         {
             return new Profile()
             {
+                name = model.Name.ModelValue,
                 outputDPI = model.OutputDPI.ModelValue,
                 yxOutputDPIRatio = model.YXRatio.ModelValue,
                 argsX = model.Acceleration.MapToDriver(),

--- a/userspace-backend/DriverConfigActivator.cs
+++ b/userspace-backend/DriverConfigActivator.cs
@@ -1,0 +1,12 @@
+namespace userspace_backend
+{
+    public interface IDriverConfigActivator
+    {
+        void Write(DriverConfig config);
+    }
+
+    public sealed class DriverConfigActivator : IDriverConfigActivator
+    {
+        public void Write(DriverConfig config) => config.Activate();
+    }
+}

--- a/userspace-backend/Logging/EditableSettingLog.cs
+++ b/userspace-backend/Logging/EditableSettingLog.cs
@@ -3,11 +3,6 @@ using Microsoft.Extensions.Logging.Abstractions;
 
 namespace userspace_backend.Logging
 {
-    /// <summary>
-    /// Ambient logger used by the generic <c>EditableSettingV2&lt;T&gt;</c> / <c>EditableSetting&lt;T&gt;</c>
-    /// classes. Each closed generic instantiation would otherwise need its own static field;
-    /// routing through a non-generic static keeps the setup to one call at app startup.
-    /// </summary>
     public static class EditableSettingLog
     {
         public static ILogger Logger { get; private set; } = NullLogger.Instance;

--- a/userspace-backend/Logging/EditableSettingLog.cs
+++ b/userspace-backend/Logging/EditableSettingLog.cs
@@ -1,0 +1,20 @@
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace userspace_backend.Logging
+{
+    /// <summary>
+    /// Ambient logger used by the generic <c>EditableSettingV2&lt;T&gt;</c> / <c>EditableSetting&lt;T&gt;</c>
+    /// classes. Each closed generic instantiation would otherwise need its own static field;
+    /// routing through a non-generic static keeps the setup to one call at app startup.
+    /// </summary>
+    public static class EditableSettingLog
+    {
+        public static ILogger Logger { get; private set; } = NullLogger.Instance;
+
+        public static void Configure(ILoggerFactory factory)
+        {
+            Logger = factory.CreateLogger("userspace_backend.EditableSetting");
+        }
+    }
+}

--- a/userspace-backend/Logging/FileLoggerProvider.cs
+++ b/userspace-backend/Logging/FileLoggerProvider.cs
@@ -6,11 +6,6 @@ using Microsoft.Extensions.Logging;
 
 namespace userspace_backend.Logging
 {
-    /// <summary>
-    /// Minimal ILoggerProvider that appends formatted log entries to a single
-    /// file. Thread-safe via a shared lock. No rotation, no size cap — this is
-    /// a diagnostic aid, not production telemetry.
-    /// </summary>
     public sealed class FileLoggerProvider : ILoggerProvider
     {
         private readonly string filePath;

--- a/userspace-backend/Logging/FileLoggerProvider.cs
+++ b/userspace-backend/Logging/FileLoggerProvider.cs
@@ -1,0 +1,100 @@
+using System;
+using System.Collections.Concurrent;
+using System.IO;
+using System.Text;
+using Microsoft.Extensions.Logging;
+
+namespace userspace_backend.Logging
+{
+    /// <summary>
+    /// Minimal ILoggerProvider that appends formatted log entries to a single
+    /// file. Thread-safe via a shared lock. No rotation, no size cap — this is
+    /// a diagnostic aid, not production telemetry.
+    /// </summary>
+    public sealed class FileLoggerProvider : ILoggerProvider
+    {
+        private readonly string filePath;
+        private readonly ConcurrentDictionary<string, FileLogger> loggers = new();
+        private readonly object writeLock = new();
+
+        public FileLoggerProvider(string filePath)
+        {
+            this.filePath = filePath;
+            var dir = Path.GetDirectoryName(filePath);
+            if (!string.IsNullOrEmpty(dir))
+            {
+                Directory.CreateDirectory(dir);
+            }
+        }
+
+        public ILogger CreateLogger(string categoryName)
+            => loggers.GetOrAdd(categoryName, name => new FileLogger(name, this));
+
+        public void Dispose() => loggers.Clear();
+
+        internal void Append(string categoryName, LogLevel level, string message, Exception? exception)
+        {
+            var sb = new StringBuilder();
+            sb.Append('[').Append(DateTime.Now.ToString("yyyy-MM-dd HH:mm:ss.fff")).Append("] ");
+            sb.Append('[').Append(level).Append("] ");
+            sb.Append('[').Append(categoryName).Append("] ");
+            sb.Append(message);
+            if (exception != null)
+            {
+                sb.AppendLine();
+                sb.Append(exception);
+            }
+            sb.AppendLine();
+
+            lock (writeLock)
+            {
+                try
+                {
+                    File.AppendAllText(filePath, sb.ToString(), Encoding.UTF8);
+                }
+                catch
+                {
+                    // Never crash the app because of a log write failure.
+                }
+            }
+        }
+
+        private sealed class FileLogger : ILogger
+        {
+            private readonly string categoryName;
+            private readonly FileLoggerProvider owner;
+
+            public FileLogger(string categoryName, FileLoggerProvider owner)
+            {
+                this.categoryName = categoryName;
+                this.owner = owner;
+            }
+
+            IDisposable ILogger.BeginScope<TState>(TState state) => NullScope.Instance;
+
+            public bool IsEnabled(LogLevel logLevel) => logLevel != LogLevel.None;
+
+            public void Log<TState>(
+                LogLevel logLevel,
+                EventId eventId,
+                TState state,
+                Exception? exception,
+                Func<TState, Exception?, string> formatter)
+            {
+                if (!IsEnabled(logLevel))
+                {
+                    return;
+                }
+
+                var message = formatter(state, exception);
+                owner.Append(categoryName, logLevel, message, exception);
+            }
+
+            private sealed class NullScope : IDisposable
+            {
+                public static readonly NullScope Instance = new();
+                public void Dispose() { }
+            }
+        }
+    }
+}

--- a/userspace-backend/Model/EditableSettings/EditableSetting.cs
+++ b/userspace-backend/Model/EditableSettings/EditableSetting.cs
@@ -1,5 +1,7 @@
 ﻿using CommunityToolkit.Mvvm.ComponentModel;
+using Microsoft.Extensions.Logging;
 using System;
+using userspace_backend.Logging;
 
 namespace userspace_backend.Model.EditableSettings
 {
@@ -146,11 +148,18 @@ namespace userspace_backend.Model.EditableSettings
             if (!Validator.Validate(data))
             {
                 UpdateInterfaceValue();
+                EditableSettingLog.Logger.LogDebug(
+                    "Setting '{Name}' ({Type}) [v1] rejected direct update: value {Value} failed validation",
+                    DisplayName, typeof(T).Name, data);
                 return false;
             }
 
+            T previous = ModelValue;
             UpdatedModeValue(data);
             UpdateInterfaceValue();
+            EditableSettingLog.Logger.LogDebug(
+                "Setting '{Name}' ({Type}) [v1] changed: {Old} -> {New}",
+                DisplayName, typeof(T).Name, previous, data);
             return true;
         }
     }
@@ -238,11 +247,17 @@ namespace userspace_backend.Model.EditableSettings
 
             if (string.IsNullOrEmpty(InterfaceValue))
             {
+                EditableSettingLog.Logger.LogDebug(
+                    "Setting '{Name}' ({Type}) commit skipped: InterfaceValue is empty",
+                    DisplayName, typeof(T).Name);
                 return false;
             }
 
             if (!Parser.TryParse(InterfaceValue.Trim(), out T parsedValue))
             {
+                EditableSettingLog.Logger.LogDebug(
+                    "Setting '{Name}' ({Type}) commit rejected: parser could not parse '{Value}'",
+                    DisplayName, typeof(T).Name, InterfaceValue);
                 return false;
             }
 
@@ -294,11 +309,18 @@ namespace userspace_backend.Model.EditableSettings
             if (!Validator.Validate(data))
             {
                 editedInterfaceNeedsReset = true;
+                EditableSettingLog.Logger.LogDebug(
+                    "Setting '{Name}' ({Type}) rejected direct update: value {Value} failed validation",
+                    DisplayName, typeof(T).Name, data);
                 return false;
             }
 
+            T previous = ModelValue;
             UpdateModeValue(data);
             SetInterfaceToModel();
+            EditableSettingLog.Logger.LogDebug(
+                "Setting '{Name}' ({Type}) changed: {Old} -> {New}",
+                DisplayName, typeof(T).Name, previous, data);
             return true;
         }
     }

--- a/userspace-backend/Model/EditableSettings/EditableSetting.cs
+++ b/userspace-backend/Model/EditableSettings/EditableSetting.cs
@@ -298,6 +298,7 @@ namespace userspace_backend.Model.EditableSettings
             }
 
             UpdateModeValue(data);
+            SetInterfaceToModel();
             return true;
         }
     }

--- a/userspace-backend/Model/EditableSettings/EditableSettingsList.cs
+++ b/userspace-backend/Model/EditableSettings/EditableSettingsList.cs
@@ -148,6 +148,8 @@ namespace userspace_backend.Model.EditableSettings
                 if (!TryGetElement(elementName, out T? element))
                 {
                     element = GenerateDefaultElement(elementName);
+                    
+                    AddElement(element);
                 }
 
                 result &= element!.TryMapFromData(dataElement);

--- a/userspace-backend/Model/EditableSettings/EditableSettingsSelector.cs
+++ b/userspace-backend/Model/EditableSettings/EditableSettingsSelector.cs
@@ -84,7 +84,15 @@ namespace userspace_backend.Model.EditableSettings
             foreach (T value in Enum.GetValues(typeof(T)))
             {
                 string key = EditableSettingsSelectorHelper.GetSelectionKey(value);
-                SelectionLookup.Add(value, serviceProvider.GetRequiredKeyedService<IEditableSettingsCollectionSpecific<U>>(key));
+                var subModel = serviceProvider.GetRequiredKeyedService<IEditableSettingsCollectionSpecific<U>>(key);
+                SelectionLookup.Add(value, subModel);
+
+                // Bubble AnySettingChanged from every sub-model up through this selector so
+                // enclosing models (e.g. ProfileModel) recompute derived state when nested
+                // parameters change. Without this, editing a curve coefficient inside the
+                // currently-selected sub-model never propagates and CurrentValidatedDriverProfile
+                // stays stale until the top-level Selection itself changes.
+                subModel.AnySettingChanged += EditableSettingsCollectionChangedEventHandler;
             }
         }
 

--- a/userspace-backend/Model/EditableSettings/EditableSettingsSelector.cs
+++ b/userspace-backend/Model/EditableSettings/EditableSettingsSelector.cs
@@ -87,11 +87,9 @@ namespace userspace_backend.Model.EditableSettings
                 var subModel = serviceProvider.GetRequiredKeyedService<IEditableSettingsCollectionSpecific<U>>(key);
                 SelectionLookup.Add(value, subModel);
 
-                // Bubble AnySettingChanged from every sub-model up through this selector so
+                // Bubble AnySettingChanged from every sub model up through this selector so
                 // enclosing models (e.g. ProfileModel) recompute derived state when nested
-                // parameters change. Without this, editing a curve coefficient inside the
-                // currently-selected sub-model never propagates and CurrentValidatedDriverProfile
-                // stays stale until the top-level Selection itself changes.
+                // parameters change.
                 subModel.AnySettingChanged += EditableSettingsCollectionChangedEventHandler;
             }
         }

--- a/userspace-backend/Model/ProfileModel.cs
+++ b/userspace-backend/Model/ProfileModel.cs
@@ -4,6 +4,8 @@ using System.Collections.ObjectModel;
 using System.ComponentModel;
 using System.Linq;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 using userspace_backend.Common;
 using userspace_backend.Display;
 using userspace_backend.Model.AccelDefinitions;
@@ -43,6 +45,8 @@ namespace userspace_backend.Model
         public const string OutputDPIDIKey = $"{nameof(ProfileModel)}.{nameof(OutputDPI)}";
         public const string YXRatioDIKey = $"{nameof(ProfileModel)}.{nameof(YXRatio)}";
 
+        private readonly ILogger<ProfileModel> logger;
+
         public ProfileModel(
             [FromKeyedServices(NameDIKey)]IEditableSettingSpecific<string> name,
             [FromKeyedServices(OutputDPIDIKey)]IEditableSettingSpecific<int> outputDPI,
@@ -50,9 +54,11 @@ namespace userspace_backend.Model
             IAccelerationModel acceleration,
             IHiddenModel hidden,
             ICurvePreview xCurvePreview,
-            ICurvePreview yCurvePreview
+            ICurvePreview yCurvePreview,
+            ILogger<ProfileModel>? logger = null
             ) : base(name, [outputDPI, yxRatio], [acceleration, hidden])
         {
+            this.logger = logger ?? NullLogger<ProfileModel>.Instance;
             OutputDPI = outputDPI;
             YXRatio = yxRatio;
             Acceleration = acceleration;
@@ -109,6 +115,7 @@ namespace userspace_backend.Model
         {
             if (string.Equals(e.PropertyName, nameof(IEditableSettingSpecific<IComparable>.ModelValue)))
             {
+                logger.LogDebug("Non-preview ModelValue changed on {Sender}", send?.GetType().Name);
                 RecalculateDriverData();
             }
         }
@@ -117,12 +124,14 @@ namespace userspace_backend.Model
         {
             if (string.Equals(e.PropertyName, nameof(IEditableSettingSpecific<IComparable>.ModelValue)))
             {
+                logger.LogDebug("Curve-preview ModelValue changed on {Sender}", send?.GetType().Name);
                 RecalculateDriverDataAndCurvePreview();
             }
         }
 
         protected void AnyCurveSettingCollectionChangedEventHandler(object? sender, EventArgs e)
         {
+            logger.LogDebug("Curve-setting collection changed: {Sender}", sender?.GetType().Name);
             // All settings collections currently require curve preview to be re-generated
             RecalculateDriverDataAndCurvePreview();
         }
@@ -130,6 +139,12 @@ namespace userspace_backend.Model
         protected void RecalculateDriverData()
         {
             CurrentValidatedDriverProfile = DriverHelpers.MapProfileModelToDriver(this);
+            logger.LogDebug(
+                "RecalculateDriverData for profile {Name}: outputDPI={OutputDPI} argsX.mode={Mode} argsX.accel={Accel}",
+                Name?.ModelValue ?? "<unnamed>",
+                CurrentValidatedDriverProfile.outputDPI,
+                CurrentValidatedDriverProfile.argsX.mode,
+                CurrentValidatedDriverProfile.argsX.acceleration);
         }
 
         protected void RecalculateDriverDataAndCurvePreview()

--- a/userspace-backend/userspace-backend.csproj
+++ b/userspace-backend/userspace-backend.csproj
@@ -11,6 +11,10 @@
   <ItemGroup>
     <PackageReference Include="CommunityToolkit.Mvvm" Version="8.2.2" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="9.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="9.0.1" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/userspace-backend/userspace-backend.csproj
+++ b/userspace-backend/userspace-backend.csproj
@@ -21,8 +21,4 @@
     <ProjectReference Include="..\wrapper\wrapper.vcxproj" />
   </ItemGroup>
 
-  <ItemGroup>
-    <InternalsVisibleTo Include="userspace-backend-tests" />
-  </ItemGroup>
-
 </Project>

--- a/userspace-backend/userspace-backend.csproj
+++ b/userspace-backend/userspace-backend.csproj
@@ -17,4 +17,8 @@
     <ProjectReference Include="..\wrapper\wrapper.vcxproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <InternalsVisibleTo Include="userspace-backend-tests" />
+  </ItemGroup>
+
 </Project>


### PR DESCRIPTION
## Apply actually hits the driver (userspace-backend/BackEnd.cs)

  - BackEnd.Apply() now builds the DriverConfig, logs it (summary + indented JSON), and calls Activate(). The old stand-alone
  WriteToDriver() helper was inlined so the config is built once and used for both logging and activation.
  - Fixed DriverHelpers.MapProfileModelToDriver not setting profile.name. The C++/CLI Profile() default populated it with the
  literal "default" from default_modifier_settings.prof, so the serialized profile name never matched the device's profile field
  and driver lookup silently fell through.
  - EnsureDefaultMappingExists rewritten to explicitly insert DefaultDeviceGroup -> "Default" on the Default mapping. The
  previous Mappings.Count == 0 guard did not self-heal stale mappings.json files that had serialized an empty GroupsToProfiles, which effectively sent zero profiles/devices to the driver on every Apply.

  ## Curve edits actually flow into CurrentValidatedDriverProfile (EditableSettingsSelector.cs)

  EditableSettingsSelector<T, U> pre-allocated every sub-model in SelectionLookup but only subscribed to the top-level Selection
  setting. Changes inside a nested sub-model (e.g. tweaking a Classic Acceleration coefficient two selector layers deep) never
  bubbled up through AnySettingChanged, so ProfileModel.RecalculateDriverData did not fire and CurrentValidatedDriverProfile
  stayed on the value captured at the last top-level selection change. Now each sub-model's AnySettingChanged is propagated up
  through the base EditableSettingsCollectionChangedEventHandler.

  ## EditableSettingV2.TryUpdateModelDirectly now syncs InterfaceValue (EditableSetting.cs)

  V2 updated ModelValue but never the paired InterfaceValue, so UI fields bound via EditableFieldViewModel.InterfaceValue kept
  showing DI defaults (name, hwid, etc.) after programmatic updates. Added a SetInterfaceToModel() call to mirror V1's behavior.

  ## Devices

  - ImportSystemDevices() + ReloadSystemDevices() on IBackEnd. App startup auto-imports real OS-enumerated mice (Name + HWID)
  into the Devices list so the driver can actually match them. ReloadSystemDevices full-syncs against the current OS list
  (removes disconnected, adds new).
  - Devices page button changed from "Add Device" to "Reload", per-row delete buttons removed (devices are now managed
  automatically).
  - Per-device expander state survives page navigation via a new PersistenceKey on EditableExpanderView keyed by HWID.

  ## Profiles

  - Profile selection: ProfilesPageViewModel.UpdateSelectedProfileView now matches by backend-model reference instead of by
  CurrentName string. The old code silently fell back to ProfileViewModels.FirstOrDefault() on any miss, which kept the main
  content frozen on Default while the sidebar highlight moved.
  - Profile list stays in sync with the backend: ProfilesPageViewModel subscribes to ProfilesModel.Profiles.CollectionChanged.
  Profiles added during a session now get a matching VM created, so clicking them actually swaps the content area.
  - Section expander state (Acceleration / Anisotropy / Coalescion / Hidden) persists across page navigation.
  - LocalizedComboBox.UpdateLocalizedItems preserves the current selection by EnumValue across a clear/re-add cycle. Without
  this, navigating away and back wiped the Acceleration combo back to None and pushed that stale selection into the backend.

 ## Persistence round-trip

  - Load path bug (EditableSettingsList.TryMapEditableSettingsCollectionsFromData): GenerateDefaultElement was called for
  profiles/devices loaded from JSON but the returned element was never inserted into ElementsInternal. Every restart silently
  discarded user-added profiles and disk-loaded devices. Added the missing AddElement(element). Affects both ProfilesModel and
  DevicesModel.
  - Save on close: new IBackEnd.SaveToDisk() (writes devices/mappings/profiles/settings to disk; no driver activation).
  desktop.ShutdownRequested calls it so edits persist without requiring an explicit Apply.

  ## Backend logging

  - Microsoft.Extensions.Logging wired end-to-end with a Console provider, a small FileLoggerProvider writing to
  logs/backend.log, and a Debug provider. In DEBUG builds the UI calls AllocConsole() on startup and re-routes Console.Out/Error
  through CONOUT$ via P/Invoke (the CLR's cached Console.Out from WinExe startup would not pick up the post-AllocConsole handle
  otherwise).
  - ILogger<BackEnd> injected into BackEnd; ILogger<ProfileModel> into ProfileModel. Apply logs the active mapping, per-profile
  summary, full DriverConfig JSON (at Debug), and Activate() success/failure.
  - A small ambient EditableSettingLog routes every TryUpdateModelDirectly / TryUpdateFromInterface commit through the logger, so
   any profile-tree field change produces a Setting 'X' ({Type}) changed: old -> new line. Diagnostic-grade, indispensable for
  tracing the curve-propagation and click-to-swap bugs.
  - Program.cs installs AppDomain.UnhandledException / TaskScheduler.UnobservedTaskException handlers that write to
  logs/crash.log before the process dies.

  ## Tests (userspace-backend-tests)

  New BackEndApplyTests fixture, 11 tests exercising the Apply pipeline without UI, disk, or driver:

  - Default-state MapToDriverConfig produces 1 profile + 1 device; device references the correct profile by name.
  - Profile OutputDPI / device DPI+PollRate edits flow into DriverConfig correctly (guards against the old pollingRate = DPI
  copy-paste bug).
  - Curve-coefficient edit two selector layers deep (Formula -> Classic -> Acceleration) propagates all the way to
  config.profiles[0].argsX.acceleration.
  - ImportSystemDevices covers dedup-by-HWID, InterfaceValue sync, and full-sync reload.
  - EnsureDefaultMapping covers both fresh install and stale empty-mappings-JSON self-heal.

  [InternalsVisibleTo("userspace-backend-tests")] on the backend assembly + MapToDriverConfig changed to protected internal so
  tests can exercise the mapping without reflection.