### PR TITLE
Fix vertical accel

### DIFF
--- a/userspace-backend/BackEndComposer.cs
+++ b/userspace-backend/BackEndComposer.cs
@@ -165,7 +165,7 @@ namespace userspace_backend
                 AnisotropyModel.CombineXYComponentsDIKey, (IServiceProvider services, object? key) =>
                     new EditableSettingV2<bool>(
                         displayName: "Combine X and Y Components",
-                        initialValue: false,
+                        initialValue: true,
                         parser: services.GetRequiredService<IUserInputParser<bool>>(),
                         validator: services.GetRequiredService<IModelValueValidator<bool>>()));
 

--- a/userspace-backend/Common/DriverHelpers.cs
+++ b/userspace-backend/Common/DriverHelpers.cs
@@ -17,6 +17,7 @@ namespace userspace_backend.Common
                 outputDPI = model.OutputDPI.ModelValue,
                 yxOutputDPIRatio = model.YXRatio.ModelValue,
                 argsX = model.Acceleration.MapToDriver(),
+                argsY = model.Acceleration.MapToDriver(),
                 domainXY = new Vec2<double>
                 {
                     x = model.Acceleration.Anisotropy.DomainX.ModelValue,

--- a/userspace-backend/Data/Profiles/Acceleration.cs
+++ b/userspace-backend/Data/Profiles/Acceleration.cs
@@ -28,7 +28,7 @@ namespace userspace_backend.Data.Profiles
             Domain = new Vector2(),
             Range = new Vector2(),
             LPNorm = 2.0,
-            CombineXYComponents = false
+            CombineXYComponents = true
         };
 
         public Coalescion Coalescion { get; set; } = new Coalescion();

--- a/userspace-backend/Model/AccelDefinitions/AccelerationModel.cs
+++ b/userspace-backend/Model/AccelDefinitions/AccelerationModel.cs
@@ -80,7 +80,7 @@ namespace userspace_backend.Model.AccelDefinitions
                     Domain = new Vector2(),
                     Range = new Vector2(),
                     LPNorm = 2.0,
-                    CombineXYComponents = false
+                    CombineXYComponents = true
                 });
 
             result &= Coalescion.TryMapFromData(data?.Coalescion);


### PR DESCRIPTION
MapProfileModelToDriver populated argsX but never argsY, so the Y axis defaulted to noaccel. In component mode this left vertical movement with no acceleration while horizontal accelerated.

Also default CombineXYComponents to true to match the old UI, so new profiles use combined accel out of the box.